### PR TITLE
feat: support creating external Add proposal

### DIFF
--- a/book/src/message_validation.md
+++ b/book/src/message_validation.md
@@ -53,21 +53,22 @@ The following is a list of the individual semantic validation steps performed by
 
 ### Semantic validation of proposals covered by a Commit
 
-| ValidationStep | Description                                                                                 | Implemented    | Tested         | Test File                                             |
-| -------------- | ------------------------------------------------------------------------------------------- | -------------- | -------------- | ----------------------------------------------------- |
-| `ValSem100`    | Add Proposal: Identity in proposals must be unique among proposals                          | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem101`    | Add Proposal: Signature public key in proposals must be unique among proposals              | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem102`    | Add Proposal: HPKE init key in proposals must be unique among proposals                     | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem103`    | Add Proposal: Identity in proposals must be unique among existing group members             | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem104`    | Add Proposal: Signature public key in proposals must be unique among existing group members | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem105`    | Add Proposal: HPKE init key in proposals must be unique among existing group members        | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem106`    | Add Proposal: required capabilities                                                         | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem107`    | Remove Proposal: Removed member must be unique among proposals                              | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem108`    | Remove Proposal: Removed member must be an existing group member                            | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem109`    | Update Proposal: Identity must be unchanged between existing member and new proposal        | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem110`    | Update Proposal: HPKE init key must be unique among existing members                        | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem111`    | Update Proposal: The sender of a full Commit must not include own update proposals          | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
-| `ValSem112`    | Update Proposal: The sender of a standalone update proposal must be of type member          | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| ValidationStep | Description                                                                                       | Implemented    | Tested         | Test File                                             |
+|----------------|---------------------------------------------------------------------------------------------------| -------------- | -------------- | ----------------------------------------------------- |
+| `ValSem100`    | Add Proposal: Identity in proposals must be unique among proposals                                | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem101`    | Add Proposal: Signature public key in proposals must be unique among proposals                    | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem102`    | Add Proposal: HPKE init key in proposals must be unique among proposals                           | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem103`    | Add Proposal: Identity in proposals must be unique among existing group members                   | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem104`    | Add Proposal: Signature public key in proposals must be unique among existing group members       | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem105`    | Add Proposal: HPKE init key in proposals must be unique among existing group members              | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem106`    | Add Proposal: required capabilities                                                               | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem107`    | Remove Proposal: Removed member must be unique among proposals                                    | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem108`    | Remove Proposal: Removed member must be an existing group member                                  | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem109`    | Update Proposal: Identity must be unchanged between existing member and new proposal              | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem110`    | Update Proposal: HPKE init key must be unique among existing members                              | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem111`    | Update Proposal: The sender of a full Commit must not include own update proposals                | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem112`    | Update Proposal: The sender of a standalone update proposal must be of type member                | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
+| `ValSem113`    | External Add Proposal: The sender of a standalone external add proposal must be of type NewMember | ✅             | ✅ | `openmls/src/group/tests/test_proposal_validation.rs` |
 
 ### Commit message validation
 

--- a/openmls/src/framing/plaintext.rs
+++ b/openmls/src/framing/plaintext.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     error::LibraryError,
     group::errors::ValidationError,
+    messages::external_proposals::ExternalProposal,
 };
 
 use super::*;
@@ -185,6 +186,33 @@ impl MlsPlaintext {
             membership_key,
             backend,
         )
+    }
+
+    /// This constructor builds an `MlsPlaintext` containing an External Proposal.
+    /// The sender type is either `Sender::Preconfigured` or `Sender::NewMember`.
+    pub(crate) fn member_external_proposal(
+        framing_parameters: FramingParameters,
+        sender: Sender,
+        proposal: ExternalProposal,
+        credential_bundle: &CredentialBundle,
+        group_id: GroupId,
+        epoch: GroupEpoch,
+        backend: &impl OpenMlsCryptoProvider,
+    ) -> Result<Self, LibraryError> {
+        let payload = Payload {
+            payload: MlsPlaintextContentType::Proposal(proposal.into()),
+            content_type: ContentType::Proposal,
+        };
+
+        let message = MlsPlaintextTbs::new(
+            framing_parameters.wire_format(),
+            group_id,
+            epoch,
+            sender,
+            vec![].into(),
+            payload,
+        );
+        message.sign(backend, credential_bundle)
     }
 
     /// This constructor builds an `MlsPlaintext` containing a Commit. If the

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -188,7 +188,7 @@ impl DecryptedMessage {
             Sender::NewMember => {
                 // Since this allows only commits or external Add proposals to have a sender type `NewMember`, it checks
                 // ValSem112
-                // ValSem113
+                // ValSem112 & ValSem113
                 match self.plaintext().content() {
                     MlsPlaintextContentType::Commit(commit) => match commit.path.as_ref() {
                         Some(path) => Ok(path.leaf_key_package().credential().clone()),

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -187,7 +187,6 @@ impl DecryptedMessage {
             Sender::Preconfigured(_) => unimplemented!(),
             Sender::NewMember => {
                 // Since this allows only commits or external Add proposals to have a sender type `NewMember`, it checks
-                // ValSem112
                 // ValSem112 & ValSem113
                 match self.plaintext().content() {
                     MlsPlaintextContentType::Commit(commit) => match commit.path.as_ref() {

--- a/openmls/src/group/errors.rs
+++ b/openmls/src/group/errors.rs
@@ -210,9 +210,9 @@ pub enum ValidationError {
     /// Message epoch differs from the group's epoch.
     #[error("Message epoch differs from the group's epoch.")]
     WrongEpoch,
-    /// The MlsPlaintext is not a Commit despite the sender begin of type NewMember.
-    #[error("The MlsPlaintext is not a Commit despite the sender begin of type NewMember.")]
-    NotACommit,
+    /// The MlsPlaintext is not a Commit or an external Add proposal despite the sender begin of type NewMember.
+    #[error("The MlsPlaintext is not a Commit or an external Add proposal despite the sender begin of type NewMember.")]
+    NotACommitOrExternalAddProposal,
     /// The Commit doesn't have a path despite the sender being of type NewMember.
     #[error("The Commit doesn't have a path despite the sender being of type NewMember.")]
     NoPath,

--- a/openmls/src/messages/external_proposals.rs
+++ b/openmls/src/messages/external_proposals.rs
@@ -22,6 +22,7 @@ use openmls_traits::OpenMlsCryptoProvider;
 ///
 /// This `enum` contains the different external proposals in its variants.
 /// Not yet implemented: `Remove` & `ReInit`
+#[non_exhaustive]
 pub enum ExternalProposal {
     /// Proposes adding a client to a group.
     /// Newly added client can be either the sender itself or not.

--- a/openmls/src/messages/external_proposals.rs
+++ b/openmls/src/messages/external_proposals.rs
@@ -1,0 +1,77 @@
+//! External Proposal
+//!
+//! Contains the types and methods to build external proposal
+//! to add a client from a MLS group
+//! `Remove` & `ReInit are nto yet implemented`
+
+use crate::{
+    credentials::CredentialBundle,
+    error::LibraryError,
+    framing::{FramingParameters, MlsMessageOut, MlsPlaintext, Sender, WireFormat},
+    group::{
+        mls_group::errors::ProposeAddMemberError,
+        GroupEpoch, GroupId,
+    },
+    key_packages::KeyPackage,
+    messages::{Proposal, AddProposal}
+};
+use openmls_traits::OpenMlsCryptoProvider;
+
+/// External Proposal.
+/// External proposal allows parties outside a group to request changes to the latter.
+///
+/// This `enum` contains the different external proposals in its variants.
+/// Not yet implemented: `Remove` & `ReInit`
+pub enum ExternalProposal {
+    /// Proposes adding a client to a group.
+    /// Newly added client can be either the sender itself or not.
+    Add(AddProposal),
+}
+
+impl From<ExternalProposal> for Proposal {
+    fn from(ext: ExternalProposal) -> Self {
+        match ext {
+            ExternalProposal::Add(add) => Self::Add(add),
+        }
+    }
+}
+
+impl ExternalProposal {
+    /// Creates a proposal to add a member to the group
+    pub fn new_add(
+        key_package: KeyPackage,
+        sender_index: Option<&[u8]>,
+        group_id: GroupId,
+        epoch: GroupEpoch,
+        credential: &CredentialBundle,
+        backend: &impl OpenMlsCryptoProvider,
+    ) -> Result<MlsMessageOut, ProposeAddMemberError> {
+        let sender = sender_index
+            .map(|r| Sender::Preconfigured(r.into()))
+            .unwrap_or(Sender::NewMember);
+        Self::Add(AddProposal { key_package })
+            .create_message(sender, group_id, epoch, credential, backend)
+            .map_err(ProposeAddMemberError::from)
+    }
+
+    fn create_message(
+        self,
+        sender: Sender,
+        group_id: GroupId,
+        epoch: GroupEpoch,
+        credential: &CredentialBundle,
+        backend: &impl OpenMlsCryptoProvider,
+    ) -> Result<MlsMessageOut, LibraryError> {
+        let framing_parameters = FramingParameters::new(&[], WireFormat::MlsPlaintext);
+        MlsPlaintext::member_external_proposal(
+            framing_parameters,
+            sender,
+            self,
+            credential,
+            group_id,
+            epoch,
+            backend,
+        )
+        .map(MlsMessageOut::from)
+    }
+}

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -28,6 +28,7 @@ use tls_codec::{Serialize as TlsSerializeTrait, *};
 // Public
 pub mod codec;
 pub mod proposals;
+pub mod external_proposals;
 pub mod public_group_state;
 
 // Tests

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -8,7 +8,7 @@ pub use crate::group::{errors::*, *};
 pub use crate::ciphersuite::{hash_ref::KeyPackageRef, signable::*, signature::*, *};
 
 // Messages
-pub use crate::messages::{proposals::*, public_group_state::*, *};
+pub use crate::messages::{proposals::*, external_proposals::*, public_group_state::*, *};
 
 // Credentials
 pub use crate::credentials::{errors::*, *};


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

[CL-8]

Adds support for creating external `Add` proposal.  
`Remove` and `ReInit` external proposals could be created afterwards

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.


[CL-8]: https://wearezeta.atlassian.net/browse/CL-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ