### PR TITLE
feat: stub x509 certificate for credentials

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,8 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-          - windows-latest
+          # latest ring version (WASM compatible) does not build on Windows (and it's fine)
+          # - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -58,4 +59,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: jetli/wasm-pack-action@v0.3.0
-      - run: wasm-pack test --headless --chrome
+      - run: wasm-pack test --headless --chrome --release

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -26,11 +26,16 @@ getrandom = { version = "0.2", features = ["js"] }
 itertools = { version = "0.10", optional = true }
 openmls_rust_crypto = { version = "0.1.0", path = "../openmls_rust_crypto", optional = true }
 openmls_evercrypt = { version = "0.1.0", path = "../evercrypt_backend", optional = true }
-rstest = {version = "^0.14", optional = true}
-rstest_reuse = {version = "0.3", optional = true}
+rstest = { version = "^0.14", optional = true }
+rstest_reuse = { version = "0.3", optional = true }
 thiserror = "^1.0"
 backtrace = "0.3"
 fluvio-wasm-timer = "0.2"
+
+[dependencies.x509-parser]
+git = "https://github.com/wireapp/x509-parser"
+branch = "master"
+features = ["verify", "validate"]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rayon = "^1.5.0"

--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -18,9 +18,8 @@ fn criterion_kp_bundle(c: &mut Criterion, backend: &impl OpenMlsCryptoProvider) 
             move |b| {
                 b.iter_with_setup(
                     || {
-                        CredentialBundle::new(
+                        CredentialBundle::new_basic(
                             vec![1, 2, 3],
-                            CredentialType::Basic,
                             ciphersuite.signature_algorithm(),
                             backend,
                         )

--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -16,8 +16,10 @@ pub struct Signature {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(any(feature = "test-utils", test), derive(PartialEq))]
 pub struct SignaturePrivateKey {
-    signature_scheme: SignatureScheme,
-    value: Vec<u8>,
+    /// cipher used for signing
+    pub signature_scheme: SignatureScheme,
+    /// key raw bytes
+    pub value: Vec<u8>,
 }
 
 /// A public signature key.

--- a/openmls/src/credentials/codec.rs
+++ b/openmls/src/credentials/codec.rs
@@ -11,38 +11,37 @@ impl tls_codec::Size for Credential {
         self.credential_type.tls_serialized_len()
             + match &self.credential {
                 MlsCredentialType::Basic(c) => c.tls_serialized_len(),
-                MlsCredentialType::X509(_) => unimplemented!(),
+                MlsCredentialType::X509(c) => c.tls_serialized_len(),
             }
     }
 }
 
 impl tls_codec::Serialize for Credential {
-    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+    fn tls_serialize<W: Write>(&self, writer: &mut W) -> Result<usize, Error> {
         match &self.credential {
             MlsCredentialType::Basic(basic_credential) => {
                 let written = CredentialType::Basic.tls_serialize(writer)?;
                 basic_credential.tls_serialize(writer).map(|l| l + written)
             }
-            // TODO #134: implement encoding for X509 certificates
-            MlsCredentialType::X509(_) => Err(tls_codec::Error::EncodingError(
-                "X509 certificates are not yet implemented.".to_string(),
-            )),
+            MlsCredentialType::X509(certificate) => {
+                let written = CredentialType::X509.tls_serialize(writer)?;
+                certificate.tls_serialize(writer).map(|l| l + written)
+            }
         }
     }
 }
 
 impl tls_codec::Deserialize for Credential {
-    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, tls_codec::Error> {
+    fn tls_deserialize<R: Read>(bytes: &mut R) -> Result<Self, Error> {
         let val = u16::tls_deserialize(bytes)?;
-        let credential_type = CredentialType::try_from(val)
-            .map_err(|e| tls_codec::Error::DecodingError(e.to_string()))?;
+        let credential_type =
+            CredentialType::try_from(val).map_err(|e| Error::DecodingError(e.to_string()))?;
         match credential_type {
             CredentialType::Basic => Ok(Credential::from(MlsCredentialType::Basic(
                 BasicCredential::tls_deserialize(bytes)?,
             ))),
-            _ => Err(tls_codec::Error::DecodingError(format!(
-                "{:?} can not be deserialized.",
-                credential_type
+            CredentialType::X509 => Ok(Credential::from(MlsCredentialType::X509(
+                Certificate::tls_deserialize(bytes)?,
             ))),
         }
     }
@@ -55,10 +54,7 @@ impl tls_codec::Deserialize for BasicCredential {
         let public_key_bytes = TlsByteVecU16::tls_deserialize(bytes)?;
         let public_key = SignaturePublicKey::new(public_key_bytes.into(), signature_scheme)
             .map_err(|e| {
-                tls_codec::Error::DecodingError(format!(
-                    "Error creating signature public key {:?}",
-                    e
-                ))
+                Error::DecodingError(format!("Error creating signature public key {:?}", e))
             })?;
         Ok(BasicCredential {
             identity,

--- a/openmls/src/credentials/errors.rs
+++ b/openmls/src/credentials/errors.rs
@@ -8,13 +8,33 @@ use thiserror::Error;
 /// An error that occurs in methods of a [`super::Credential`].
 #[derive(Error, Debug, PartialEq, Clone)]
 pub enum CredentialError {
-    /// A library error occured.
+    /// A library error occurred.
     #[error(transparent)]
     LibraryError(#[from] LibraryError),
     /// The type of credential is not supported.
     #[error("Unsupported credential type.")]
     UnsupportedCredentialType,
+    /// The type of cipher is not supported.
+    #[error("Unsupported cipher.")]
+    UnsupportedSignatureScheme,
     /// Verifying the signature with this credential failed.
     #[error("Invalid signature.")]
     InvalidSignature,
+    /// Parsing raw DER x509 certificate failed
+    #[error("Invalid x509 certificate format.")]
+    // TODO: replace by this when error no longer require Clone and PartialEq
+    // InvalidCertificateFormat(#[from] x509_parser::nom::Err<x509_parser::prelude::X509Error>),
+    InvalidCertificateFormat,
+    /// x509 certificate is expired or not valid yet
+    #[error("x509 certificate is expired or not valid yet.")]
+    InvalidCertificate,
+    /// x509 certificate lacks some fields required by MLS
+    #[error("x509 certificate lacks required field {0}.")]
+    IncompleteCertificate(String),
+    /// Incomplete x509 certificate chain
+    #[error("x509 certificate chain is either empty or contains a single self-signed certificate which is not allowed.")]
+    IncompleteCertificateChain,
+    /// x509 certificate chain is either unordered or a child is missigned by its issuer
+    #[error("Invalid x509 certificate chain.")]
+    InvalidCertificateChain,
 }

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -36,9 +36,13 @@ use openmls_traits::{
 };
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
+use std::io::Write;
 #[cfg(test)]
 use tls_codec::Serialize as TlsSerializeTrait;
-use tls_codec::{TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize};
+use tls_codec::{Error, TlsByteVecU16, TlsDeserialize, TlsSerialize, TlsSize, TlsVecU16};
+use x509_parser::der_parser::asn1_rs::oid;
+use x509_parser::der_parser::Oid;
+use x509_parser::prelude::{Logger, Validator, X509Certificate, X509StructureValidator};
 
 use crate::{ciphersuite::*, error::LibraryError};
 
@@ -81,9 +85,118 @@ impl TryFrom<u16> for CredentialType {
 ///
 /// This struct contains an X.509 certificate chain.  Note that X.509
 /// certificates are not yet supported by OpenMLS.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug, PartialEq, Clone, Serialize, Deserialize, TlsDeserialize, TlsSerialize, TlsSize,
+)]
 pub struct Certificate {
-    cert_data: Vec<u8>,
+    identity: TlsByteVecU16,
+    cert_chain: TlsVecU16<TlsByteVecU16>,
+}
+
+impl Certificate {
+    fn parse(&self) -> Result<Vec<X509Certificate>, CredentialError> {
+        self.cert_chain.iter().try_fold(
+            Vec::new(),
+            |mut acc, certificate| -> Result<Vec<X509Certificate>, CredentialError> {
+                acc.push(Self::parse_single(certificate)?);
+                Ok(acc)
+            },
+        )
+    }
+
+    fn parse_single(certificate: &TlsByteVecU16) -> Result<X509Certificate, CredentialError> {
+        use x509_parser::nom::Parser as _;
+
+        let mut parser = x509_parser::certificate::X509CertificateParser::new()
+            .with_deep_parse_extensions(false);
+        parser
+            .parse(certificate.as_slice())
+            .map(|(_, cert)| cert)
+            .map_err(|_| CredentialError::InvalidCertificateFormat)
+    }
+
+    /// Is signed by issuer
+    fn is_verified(
+        certificate: &X509Certificate,
+        issuer: &X509Certificate,
+    ) -> Result<(), CredentialError> {
+        certificate
+            .verify_signature(Some(&issuer.subject_pki))
+            .map_err(|_| CredentialError::InvalidCertificateChain)
+    }
+
+    fn is_valid<'a>(
+        certificate: &'a X509Certificate,
+    ) -> Result<&'a X509Certificate<'a>, CredentialError> {
+        if Self::is_time_valid(certificate) && Self::is_structure_valid(certificate) {
+            Ok(certificate)
+        } else {
+            Err(CredentialError::InvalidCertificate)
+        }
+    }
+
+    fn is_structure_valid(certificate: &X509Certificate) -> bool {
+        // validates structure (fields etc..)
+        struct NoopLogger;
+        impl Logger for NoopLogger {
+            fn warn(&mut self, _: &str) {}
+            fn err(&mut self, _: &str) {}
+        }
+        X509StructureValidator.validate(certificate, &mut NoopLogger)
+    }
+
+    fn is_time_valid(certificate: &X509Certificate) -> bool {
+        // 'not_before' < now < 'not_after'
+        certificate.validity().is_valid()
+    }
+
+    fn signature_scheme(certificate: &X509Certificate) -> Result<SignatureScheme, CredentialError> {
+        // see https://github.com/bcgit/bc-java/blob/r1rv71/core/src/main/java/org/bouncycastle/asn1/edec/EdECObjectIdentifiers.java
+        const ED25519: Oid = oid!(1.3.101 .112);
+        const ED448: Oid = oid!(1.3.101 .113);
+        // see https://github.com/bcgit/bc-java/blob/r1rv71/core/src/main/java/org/bouncycastle/asn1/x9/X9ObjectIdentifiers.java
+        const ECDSA_SHA256: Oid = oid!(1.2.840 .10045 .4 .3 .2);
+        const ECDSA_SHA384: Oid = oid!(1.2.840 .10045 .4 .3 .3);
+        const ECDSA_SHA512: Oid = oid!(1.2.840 .10045 .4 .3 .4);
+        // for signature algorithm parameters
+        // see https://www.rfc-editor.org/rfc/rfc7670.html#appendix-A.1
+        const SECP_256_R1: Oid = oid!(1.2.840 .10045 .3 .1 .7);
+        // see https://datatracker.ietf.org/doc/html/rfc5480#section-2.1.1.1
+        const SECP_384_R1: Oid = oid!(1.3.132 .0 .34);
+        const SECP_521_R1: Oid = oid!(1.3.132 .0 .35);
+
+        let alg = &certificate.signature_algorithm.algorithm;
+        let params = certificate
+            .signature_algorithm
+            .parameters
+            .as_ref()
+            .and_then(|p| p.as_oid().ok());
+
+        if *alg == ED25519 {
+            Ok(SignatureScheme::ED25519)
+        } else if *alg == ED448 {
+            Ok(SignatureScheme::ED448)
+        } else if *alg == ECDSA_SHA256 && params == Some(SECP_256_R1) {
+            Ok(SignatureScheme::ECDSA_SECP256R1_SHA256)
+        } else if *alg == ECDSA_SHA384 && params == Some(SECP_384_R1) {
+            Ok(SignatureScheme::ECDSA_SECP384R1_SHA384)
+        } else if *alg == ECDSA_SHA512 && params == Some(SECP_521_R1) {
+            Ok(SignatureScheme::ECDSA_SECP521R1_SHA512)
+        } else {
+            Err(CredentialError::UnsupportedSignatureScheme)
+        }
+    }
+
+    fn public_key(certificate: &X509Certificate) -> Result<SignaturePublicKey, CredentialError> {
+        let public_key = &certificate.subject_pki.subject_public_key;
+        let signature_scheme = Self::signature_scheme(certificate);
+        SignaturePublicKey::new(public_key.data.to_vec(), signature_scheme?)
+            .map_err(|_| CredentialError::IncompleteCertificate("subjectPublicKeyInfo".to_string()))
+    }
+
+    fn leaf_certificate(&self) -> &TlsByteVecU16 {
+        &self.cert_chain[0]
+    }
 }
 
 /// MlsCredentialType.
@@ -124,7 +237,37 @@ impl Credential {
                 .verify(backend, signature, payload)
                 .map_err(|_| CredentialError::InvalidSignature),
             // TODO: implement verification for X509 certificates. See issue #134.
-            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::X509(certificate_chain) => {
+                let certificates = certificate_chain.parse()?;
+                certificates
+                    .iter()
+                    .enumerate()
+                    .map(Ok)
+                    .reduce(
+                        |a, b| -> Result<(usize, &X509Certificate), CredentialError> {
+                            let (current_index, current) = a?;
+                            let (next_index, next) = b?;
+                            if current_index == 0 {
+                                // this is leaf certificate
+                                Certificate::public_key(current)?
+                                    // verify that payload is signed by leaf certificate
+                                    .verify(backend, signature, payload)
+                                    .map_err(|_| CredentialError::InvalidSignature)?;
+                            }
+                            // is valid in time + x509 structure (fields etc..)
+                            Certificate::is_valid(current)
+                                // verifies current signed by issuer
+                                .and(Certificate::is_verified(current, next))?;
+                            Ok((next_index, next))
+                        },
+                    )
+                    .ok_or_else(|| {
+                        CredentialError::LibraryError(LibraryError::custom(
+                            "Cannot have validated an empty certificate chain",
+                        ))
+                    })?
+                    .map(|_| ())
+            }
         }
     }
 
@@ -133,23 +276,41 @@ impl Credential {
         match &self.credential {
             MlsCredentialType::Basic(basic_credential) => basic_credential.identity.as_slice(),
             // TODO: implement getter for identity for X509 certificates. See issue #134.
-            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::X509(certificate_chain) => {
+                // TODO: (wire) implement x509 properly. Identity should be extracted from leaf certificate e.g. serial + subj alt name
+                certificate_chain.identity.as_slice()
+            }
         }
     }
 
     /// Returns the signature scheme used by the credential.
-    pub fn signature_scheme(&self) -> SignatureScheme {
+    pub fn signature_scheme(&self) -> Result<SignatureScheme, CredentialError> {
         match &self.credential {
-            MlsCredentialType::Basic(basic_credential) => basic_credential.signature_scheme,
-            // TODO: implement getter for signature scheme for X509 certificates. See issue #134.
-            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::Basic(basic_credential) => Ok(basic_credential.signature_scheme),
+            MlsCredentialType::X509(certificate_chain) => {
+                // TODO: implement getter for signature scheme for X509 certificates. See issue #134.
+                // TODO: (wire) highly inefficient, parsing certificate twice to avoid propagating lifetime everywhere
+                let leaf = certificate_chain.leaf_certificate();
+                let leaf = Certificate::parse_single(leaf)?;
+                Certificate::signature_scheme(&leaf)
+            }
         }
     }
+
     /// Returns the public key contained in the credential.
     pub fn signature_key(&self) -> &SignaturePublicKey {
         match &self.credential {
             MlsCredentialType::Basic(basic_credential) => &basic_credential.public_key,
-            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::X509(certificates) => {
+                // TODO: (wire) implement x509 properly
+                let leaf = certificates.leaf_certificate();
+                // should be safe as we already have checked certificate beforehand
+                // TODO: (wire) highly inefficient, parsing certificate twice to avoid propagating lifetime everywhere
+                let leaf = Certificate::parse_single(leaf).unwrap();
+                let signature_key = Certificate::public_key(&leaf).unwrap();
+                // TODO: conscious memory leak
+                Box::leak(Box::new(signature_key))
+            }
         }
     }
 }
@@ -212,31 +373,50 @@ pub struct CredentialBundle {
 }
 
 impl CredentialBundle {
-    /// Creates and returns a new [`CredentialBundle`] of the given
-    /// [`CredentialType`] for the given identity and [`SignatureScheme`]. The
-    /// corresponding key material is freshly generated.
-    ///
-    /// Returns an error if the given [`CredentialType`] is not supported.
-    pub fn new(
+    /// Creates and returns a new basic [`CredentialBundle`] for the given identity and [`SignatureScheme`].
+    /// The corresponding key material is freshly generated.
+    pub fn new_basic(
         identity: Vec<u8>,
-        credential_type: CredentialType,
         signature_scheme: SignatureScheme,
         backend: &impl OpenMlsCryptoProvider,
     ) -> Result<Self, CredentialError> {
         let (private_key, public_key) = SignatureKeypair::new(signature_scheme, backend)
             .map_err(LibraryError::unexpected_crypto_error)?
             .into_tuple();
-        let mls_credential = match credential_type {
-            CredentialType::Basic => BasicCredential {
+        let credential = Credential {
+            credential_type: CredentialType::Basic,
+            credential: MlsCredentialType::Basic(BasicCredential {
                 identity: identity.into(),
                 signature_scheme,
                 public_key,
-            },
-            _ => return Err(CredentialError::UnsupportedCredentialType),
+            }),
         };
+        Ok(CredentialBundle {
+            credential,
+            signature_private_key: private_key,
+        })
+    }
+
+    /// Creates and returns a new x509 [`CredentialBundle`]
+    pub fn new_x509(
+        identity: Vec<u8>,
+        cert_chain: Vec<Vec<u8>>,
+        private_key: SignaturePrivateKey,
+    ) -> Result<Self, CredentialError> {
+        if cert_chain.len() < 2 {
+            return Err(CredentialError::IncompleteCertificateChain);
+        }
+        let cert_chain = cert_chain
+            .into_iter()
+            .map(|c| c.into())
+            .collect::<TlsVecU16<_>>();
         let credential = Credential {
-            credential_type,
-            credential: MlsCredentialType::Basic(mls_credential),
+            credential_type: CredentialType::X509,
+            // TODO: (wire) implement x509 properly. Identity should not be there and extracted from certificate instead
+            credential: MlsCredentialType::X509(Certificate {
+                identity: identity.into(),
+                cert_chain,
+            }),
         };
         Ok(CredentialBundle {
             credential,

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -96,16 +96,14 @@ fn ratchet_tree_extension(ciphersuite: Ciphersuite, backend: &impl OpenMlsCrypto
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -31,9 +31,8 @@ use crate::{
 /// This tests serializing/deserializing MlsPlaintext
 #[apply(ciphersuites_and_backends)]
 fn codec_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         vec![7, 8, 9],
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -81,9 +80,8 @@ fn codec_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 /// This tests serializing/deserializing MlsCiphertext
 #[apply(ciphersuites_and_backends)]
 fn codec_ciphertext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         vec![7, 8, 9],
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -161,9 +159,8 @@ fn codec_ciphertext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
 #[apply(ciphersuites_and_backends)]
 fn wire_format_checks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     let configuration = &SenderRatchetConfiguration::default();
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         vec![7, 8, 9],
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -307,9 +304,8 @@ fn wire_format_checks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
 
 #[apply(ciphersuites_and_backends)]
 fn membership_tag(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         vec![7, 8, 9],
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -369,23 +365,20 @@ fn unknown_sender(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     let configuration = &SenderRatchetConfiguration::default();
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let charlie_credential_bundle = CredentialBundle::new(
+    let charlie_credential_bundle = CredentialBundle::new_basic(
         "Charlie".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -579,16 +572,14 @@ fn confirmation_tag_presence(ciphersuite: Ciphersuite, backend: &impl OpenMlsCry
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -683,16 +674,14 @@ fn invalid_plaintext_signature(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -20,9 +20,8 @@ use crate::{
 #[apply(ciphersuites_and_backends)]
 fn test_core_group_persistence(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -81,9 +80,8 @@ fn test_failed_groupinfo_decryption(
         mac_value: vec![1, 2, 3, 4, 5, 6, 7, 8, 9].into(),
     });
 
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -179,16 +177,14 @@ fn test_update_path(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -365,16 +361,14 @@ fn test_psks(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -511,16 +505,14 @@ fn test_staged_commit_creation(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -603,9 +595,8 @@ fn test_own_commit_processing(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -649,9 +640,8 @@ fn setup_client(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (CredentialBundle, KeyPackageBundle) {
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         id.into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/group/core_group/test_create_commit_params.rs
+++ b/openmls/src/group/core_group/test_create_commit_params.rs
@@ -1,7 +1,7 @@
 use core_group::{create_commit_params::CreateCommitParams, proposals::ProposalStore};
 use openmls_traits::types::SignatureScheme;
 
-use crate::{credentials::CredentialType, test_utils::*};
+use crate::test_utils::*;
 
 use super::*;
 
@@ -10,9 +10,8 @@ use super::*;
 fn build_create_commit_params(backend: &impl OpenMlsCryptoProvider) {
     let framing_parameters: FramingParameters =
         FramingParameters::new(&[1, 2, 3], WireFormat::MlsCiphertext);
-    let credential_bundle: &CredentialBundle = &CredentialBundle::new(
+    let credential_bundle: &CredentialBundle = &CredentialBundle::new_basic(
         vec![4, 5, 6],
-        CredentialType::Basic,
         SignatureScheme::ED25519,
         backend,
     )

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -20,16 +20,14 @@ fn duplicate_ratchet_tree_extension(
     let group_aad = b"Alice's test group";
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/group/core_group/test_external_init.rs
+++ b/openmls/src/group/core_group/test_external_init.rs
@@ -1,5 +1,5 @@
 use crate::{
-    credentials::{CredentialBundle, CredentialType},
+    credentials::CredentialBundle,
     framing::{FramingParameters, WireFormat},
     group::GroupId,
     key_packages::KeyPackageBundle,
@@ -27,16 +27,14 @@ fn test_external_init(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -102,9 +100,8 @@ fn test_external_init(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
 
     // Now set up charly and try to init externally.
     // Define credential bundles
-    let charly_credential_bundle = CredentialBundle::new(
+    let charly_credential_bundle = CredentialBundle::new_basic(
         "Charly".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -268,9 +265,8 @@ fn test_external_init_single_member_group(
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -294,9 +290,8 @@ fn test_external_init_single_member_group(
 
     // Now set up charly and try to init externally.
     // Define credential bundles
-    let charly_credential_bundle = CredentialBundle::new(
+    let charly_credential_bundle = CredentialBundle::new_basic(
         "Charly".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/group/core_group/test_proposals.rs
+++ b/openmls/src/group/core_group/test_proposals.rs
@@ -7,7 +7,7 @@ use crate::{
         hash_ref::{KeyPackageRef, ProposalRef},
         Secret,
     },
-    credentials::{CredentialBundle, CredentialType},
+    credentials::{CredentialBundle},
     extensions::{Extension, ExtensionType, ExternalKeyIdExtension, RequiredCapabilitiesExtension},
     framing::sender::Sender,
     framing::{FramingParameters, MlsPlaintext, WireFormat},
@@ -30,9 +30,8 @@ fn setup_client(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (CredentialBundle, KeyPackageBundle) {
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         id.into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -18,10 +18,10 @@ use crate::{
 fn generate_credential_bundle(
     key_store: &impl OpenMlsCryptoProvider,
     identity: Vec<u8>,
-    credential_type: CredentialType,
+    _credential_type: CredentialType,
     signature_scheme: SignatureScheme,
 ) -> Result<Credential, CredentialError> {
-    let cb = CredentialBundle::new(identity, credential_type, signature_scheme, key_store)?;
+    let cb = CredentialBundle::new_basic(identity, signature_scheme, key_store)?;
     let credential = cb.credential().clone();
     key_store
         .key_store()

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -59,9 +59,8 @@ pub struct MessagesTestVector {
 pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     let crypto = OpenMlsRustCrypto::default();
     let ciphersuite_name = ciphersuite;
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         b"OpenMLS rocks".to_vec(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite_name),
         &crypto,
     )
@@ -131,9 +130,8 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> MessagesTestVector {
     };
 
     // Create proposal to add a user
-    let joiner_credential_bundle = CredentialBundle::new(
+    let joiner_credential_bundle = CredentialBundle::new_basic(
         b"MLS rocks".to_vec(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite_name),
         &crypto,
     )

--- a/openmls/src/group/tests/kat_transcripts.rs
+++ b/openmls/src/group/tests/kat_transcripts.rs
@@ -63,9 +63,8 @@ pub fn generate_test_vector(ciphersuite: Ciphersuite) -> TranscriptTestVector {
     );
 
     // Build plaintext commit message.
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         b"client".to_vec(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite),
         &crypto,
     )

--- a/openmls/src/group/tests/test_group.rs
+++ b/openmls/src/group/tests/test_group.rs
@@ -18,16 +18,14 @@ fn create_commit_optional_path(ciphersuite: Ciphersuite, backend: &impl OpenMlsC
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define identities
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -208,16 +206,14 @@ fn basic_group_setup(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvi
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -288,16 +284,14 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     let sender_ratchet_configuration = SenderRatchetConfiguration::default();
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -612,9 +606,8 @@ fn group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvid
     }
 
     // === Bob adds Charlie ===
-    let charlie_credential_bundle = CredentialBundle::new(
+    let charlie_credential_bundle = CredentialBundle::new_basic(
         "Charlie".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/group/tests/test_past_secrets.rs
+++ b/openmls/src/group/tests/test_past_secrets.rs
@@ -8,7 +8,7 @@ use rstest::*;
 use rstest_reuse::{self, *};
 
 use crate::{
-    credentials::{CredentialBundle, CredentialType},
+    credentials::{CredentialBundle},
     framing::{MessageDecryptionError, ProcessedMessage},
     group::{errors::*, *},
     key_packages::KeyPackageBundle,
@@ -22,9 +22,8 @@ fn test_past_secrets_in_group(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
 
         // Generate credential bundles
 
-        let alice_credential_bundle = CredentialBundle::new(
+        let alice_credential_bundle = CredentialBundle::new_basic(
             "Alice".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )
@@ -41,9 +40,8 @@ fn test_past_secrets_in_group(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
             )
             .expect("An unexpected error occurred.");
 
-        let bob_credential_bundle = CredentialBundle::new(
+        let bob_credential_bundle = CredentialBundle::new_basic(
             "Bob".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -1615,9 +1615,8 @@ fn test_valsem109(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider
     // proposal by bob that changes his identity.
 
     // We begin by creating a KPB with a different identity.
-    let new_cb = CredentialBundle::new(
+    let new_cb = CredentialBundle::new_basic(
         "Bobby".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -94,9 +94,8 @@ pub(crate) fn setup(config: TestSetupConfig, backend: &impl OpenMlsCryptoProvide
         // signature scheme), as well as 10 KeyPackages per ciphersuite.
         for ciphersuite in client.ciphersuites {
             // Create a credential_bundle for the given ciphersuite.
-            let credential_bundle = CredentialBundle::new(
+            let credential_bundle = CredentialBundle::new_basic(
                 client.name.as_bytes().to_vec(),
-                CredentialType::Basic,
                 SignatureScheme::from(ciphersuite),
                 backend,
             )
@@ -340,11 +339,11 @@ fn test_setup(backend: &impl OpenMlsCryptoProvider) {
 // Helper function to generate a CredentialBundle
 pub(super) fn generate_credential_bundle(
     identity: Vec<u8>,
-    credential_type: CredentialType,
+    _credential_type: CredentialType,
     signature_scheme: SignatureScheme,
     backend: &impl OpenMlsCryptoProvider,
 ) -> Result<Credential, CredentialError> {
-    let cb = CredentialBundle::new(identity, credential_type, signature_scheme, backend)?;
+    let cb = CredentialBundle::new_basic(identity, signature_scheme, backend)?;
     let credential = cb.credential().clone();
     backend
         .key_store()

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -34,9 +34,8 @@
 //! let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 //! let backend = OpenMlsRustCrypto::default();
 //!
-//! let credential_bundle = CredentialBundle::new(
+//! let credential_bundle = CredentialBundle::new_basic(
 //!     b"Sasha".to_vec(),
-//!     CredentialType::Basic,
 //!     SignatureScheme::from(ciphersuite),
 //!     &backend,
 //! )
@@ -372,7 +371,7 @@ impl KeyPackage {
         credential_bundle: &CredentialBundle,
         extensions: Vec<Extension>,
     ) -> Result<Self, KeyPackageNewError> {
-        if SignatureScheme::from(ciphersuite) != credential_bundle.credential().signature_scheme() {
+        if Ok(SignatureScheme::from(ciphersuite)) != credential_bundle.credential().signature_scheme() {
             return Err(KeyPackageNewError::CiphersuiteSignatureSchemeMismatch);
         }
         let key_package = KeyPackagePayload {
@@ -597,9 +596,7 @@ impl KeyPackageBundle {
             return Err(error);
         }
 
-        if SignatureScheme::from(ciphersuites[0])
-            != credential_bundle.credential().signature_scheme()
-        {
+        if Ok(SignatureScheme::from(ciphersuites[0])) != credential_bundle.credential().signature_scheme() {
             return Err(KeyPackageBundleNewError::CiphersuiteSignatureSchemeMismatch);
         }
 

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -6,9 +6,8 @@ use crate::{extensions::*, key_packages::*};
 
 #[apply(ciphersuites_and_backends)]
 fn generate_key_package(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         vec![1, 2, 3],
-        CredentialType::Basic,
         ciphersuite.into(),
         backend,
     )
@@ -56,7 +55,7 @@ fn decryption_key_index_computation(
 ) {
     let id = vec![1, 2, 3];
     let credential_bundle =
-        CredentialBundle::new(id, CredentialType::Basic, ciphersuite.into(), backend)
+        CredentialBundle::new_basic(id, ciphersuite.into(), backend)
             .expect("An unexpected error occurred.");
     let mut kpb = KeyPackageBundle::new(&[ciphersuite], &credential_bundle, backend, Vec::new())
         .expect("An unexpected error occurred.")
@@ -81,7 +80,7 @@ fn decryption_key_index_computation(
 fn key_package_id_extension(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     let id = vec![1, 2, 3];
     let credential_bundle =
-        CredentialBundle::new(id, CredentialType::Basic, ciphersuite.into(), backend)
+        CredentialBundle::new_basic(id, ciphersuite.into(), backend)
             .expect("An unexpected error occurred.");
     let kpb = KeyPackageBundle::new(
         &[ciphersuite],
@@ -117,9 +116,8 @@ fn test_mismatch(backend: &impl OpenMlsCryptoProvider) {
     let ciphersuite_name = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let signature_scheme = SignatureScheme::ECDSA_SECP256R1_SHA256;
 
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         vec![1, 2, 3],
-        CredentialType::Basic,
         signature_scheme,
         backend,
     )
@@ -135,9 +133,8 @@ fn test_mismatch(backend: &impl OpenMlsCryptoProvider) {
     let ciphersuite_name = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let signature_scheme = SignatureScheme::ED25519;
 
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         vec![1, 2, 3],
-        CredentialType::Basic,
         signature_scheme,
         backend,
     )

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -22,7 +22,7 @@
 //!     backend: &impl OpenMlsCryptoProvider,
 //! ) -> Result<Credential, CredentialError> {
 //!     let credential_bundle =
-//!         CredentialBundle::new(identity, credential_type, signature_algorithm, backend)?;
+//!         CredentialBundle::new_basic(identity, signature_algorithm, backend)?;
 //!     let credential_id =  credential_bundle.credential()
 //!         .signature_key()
 //!         .tls_serialize_detached()

--- a/openmls/src/messages/codec.rs
+++ b/openmls/src/messages/codec.rs
@@ -101,7 +101,7 @@ impl tls_codec::Deserialize for Proposal {
         let proposal_type = match ProposalType::try_from(u16::tls_deserialize(bytes)?) {
             Ok(proposal_type) => proposal_type,
             Err(e) => {
-                return Err(tls_codec::Error::DecodingError(format!(
+                return Err(Error::DecodingError(format!(
                     "Deserialization error {}",
                     e
                 )))
@@ -118,7 +118,7 @@ impl tls_codec::Deserialize for Proposal {
             ProposalType::ExternalInit => Ok(Proposal::ExternalInit(
                 ExternalInitProposal::tls_deserialize(bytes)?,
             )),
-            ProposalType::AppAck => Err(tls_codec::Error::DecodingError(
+            ProposalType::AppAck => Err(Error::DecodingError(
                 "App ack is not supported yet in OpenMLS.".to_string(),
             )),
             ProposalType::GroupContextExtensions => Ok(Proposal::GroupContextExtensions(

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -166,7 +166,7 @@ impl Commit {
 )]
 pub struct ConfirmationTag(pub(crate) Mac);
 
-#[derive(TlsDeserialize, TlsSerialize, TlsSize)]
+#[derive(Debug, TlsDeserialize, TlsSerialize, TlsSize)]
 pub(crate) struct GroupInfoPayload {
     group_id: GroupId,
     epoch: GroupEpoch,
@@ -231,6 +231,7 @@ impl Signable for GroupInfoPayload {
 ///   opaque signature<0..2^16-1>;
 /// } GroupInfo;
 /// ```
+#[derive(Debug)]
 pub(crate) struct GroupInfo {
     payload: GroupInfoPayload,
     signature: Signature,

--- a/openmls/src/messages/tests/test_pgs.rs
+++ b/openmls/src/messages/tests/test_pgs.rs
@@ -17,16 +17,14 @@ fn test_pgs(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::MlsPlaintext);
 
     // Define credential bundles
-    let alice_credential_bundle = CredentialBundle::new(
+    let alice_credential_bundle = CredentialBundle::new_basic(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
-    let bob_credential_bundle = CredentialBundle::new(
+    let bob_credential_bundle = CredentialBundle::new_basic(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/messages/tests/test_welcome.rs
+++ b/openmls/src/messages/tests/test_welcome.rs
@@ -3,7 +3,7 @@
 use crate::{
     ciphersuite::hash_ref::KeyPackageRef,
     ciphersuite::{signable::Signable, AeadKey, AeadNonce, Mac, Secret},
-    credentials::{CredentialBundle, CredentialType},
+    credentials::{CredentialBundle},
     group::GroupId,
     messages::{ConfirmationTag, EncryptedGroupSecrets, GroupInfoPayload, Welcome},
     versions::ProtocolVersion,
@@ -48,9 +48,8 @@ fn test_welcome_message_with_version(
     );
 
     // We need a credential bundle to sign the group info.
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         "XXX".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -132,9 +132,8 @@ impl MlsGroupTestSetup {
             let crypto = OpenMlsRustCrypto::default();
             let mut credentials = HashMap::new();
             for ciphersuite in crypto.crypto().supported_ciphersuites().iter() {
-                let cb = CredentialBundle::new(
+                let cb = CredentialBundle::new_basic(
                     identity.clone(),
-                    CredentialType::Basic,
                     SignatureScheme::from(*ciphersuite),
                     &crypto,
                 )

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -81,7 +81,7 @@ use crate::{
     ciphersuite::Secret, messages::proposals::RemoveProposal, tree::index::SecretTreeLeafIndex,
 };
 use crate::{
-    credentials::{CredentialBundle, CredentialType},
+    credentials::CredentialBundle,
     framing::*,
     group::*,
     key_packages::KeyPackageBundle,
@@ -142,9 +142,8 @@ fn group(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (CoreGroup, CredentialBundle) {
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         "Kreator".into(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite),
         backend,
     )
@@ -166,9 +165,8 @@ fn receiver_group(
     backend: &impl OpenMlsCryptoProvider,
     group_id: &GroupId,
 ) -> CoreGroup {
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         "Receiver".into(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite),
         backend,
     )

--- a/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
+++ b/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
@@ -3,7 +3,7 @@ use rstest::*;
 use rstest_reuse::apply;
 
 use crate::{
-    credentials::{CredentialBundle, CredentialType},
+    credentials::{CredentialBundle},
     key_packages::KeyPackageBundle,
     treesync::{node::Node, TreeSync},
 };
@@ -13,9 +13,8 @@ use openmls_rust_crypto::OpenMlsRustCrypto;
 // Verifies that when we add a leaf to a tree with blank leaf nodes, the leaf will be added at the leftmost free leaf index
 #[apply(ciphersuites_and_backends)]
 fn test_free_leaf_computation(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let cb_0 = CredentialBundle::new(
+    let cb_0 = CredentialBundle::new_basic(
         "leaf0".as_bytes().to_vec(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -24,9 +23,8 @@ fn test_free_leaf_computation(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
     let kpb_0 =
         KeyPackageBundle::new(&[ciphersuite], &cb_0, backend, vec![]).expect("error creating kpb");
 
-    let cb_3 = CredentialBundle::new(
+    let cb_3 = CredentialBundle::new_basic(
         "leaf3".as_bytes().to_vec(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -49,9 +47,8 @@ fn test_free_leaf_computation(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
 
     // Create and add a new leaf. It should go to leaf index 1
 
-    let cb_2 = CredentialBundle::new(
+    let cb_2 = CredentialBundle::new_basic(
         "leaf2".as_bytes().to_vec(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -8,13 +8,12 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 fn generate_credential_bundle(
     identity: Vec<u8>,
-    credential_type: CredentialType,
     signature_algorithm: SignatureScheme,
     backend: &impl OpenMlsCryptoProvider,
 ) -> Result<Credential, CredentialError> {
     // ANCHOR: create_credential_bundle
     let credential_bundle =
-        CredentialBundle::new(identity, credential_type, signature_algorithm, backend)?;
+        CredentialBundle::new_basic(identity, signature_algorithm, backend)?;
     // ANCHOR_END: create_credential_bundle
     // ANCHOR: store_credential_bundle
     let credential = credential_bundle.credential().clone();
@@ -100,7 +99,6 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
     // Generate credential bundles
     let alice_credential = generate_credential_bundle(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -108,7 +106,6 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 
     let bob_credential = generate_credential_bundle(
         "Bob".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -116,7 +113,6 @@ fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvide
 
     let charlie_credential = generate_credential_bundle(
         "Charlie".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -1087,7 +1083,6 @@ fn test_empty_input_errors(ciphersuite: Ciphersuite, backend: &impl OpenMlsCrypt
     // Generate credential bundles
     let alice_credential = generate_credential_bundle(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/tests/key_store.rs
+++ b/openmls/tests/key_store.rs
@@ -10,9 +10,8 @@ wasm_bindgen_test_configure!(run_in_browser);
 fn test_store_key_package_bundle(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // ANCHOR: key_store_store
     // First we generate a credential and key package for our user.
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         b"User ID".to_vec(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite),
         backend,
     )
@@ -48,9 +47,8 @@ fn test_store_key_package_bundle(ciphersuite: Ciphersuite, backend: &impl OpenMl
 #[wasm_bindgen_test]
 fn test_read_credential_bundle(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // First we generate a credential bundle
-    let credential_bundle_to_store = CredentialBundle::new(
+    let credential_bundle_to_store = CredentialBundle::new_basic(
         b"User ID".to_vec(),
-        CredentialType::Basic,
         SignatureScheme::from(ciphersuite),
         backend,
     )

--- a/openmls/tests/test_key_packages.rs
+++ b/openmls/tests/test_key_packages.rs
@@ -11,13 +11,13 @@ fn key_package_generation(ciphersuite: Ciphersuite, backend: &impl OpenMlsCrypto
     println!("Testing ciphersuite {:?}", ciphersuite);
 
     let id = vec![1, 2, 3];
-    let credential_bundle = CredentialBundle::new(
+    let credential_bundle = CredentialBundle::new_basic(
         id,
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
     .expect("An unexpected error occurred.");
+
     let kpb = KeyPackageBundle::new(&[ciphersuite], &credential_bundle, backend, Vec::new())
         .expect("An unexpected error occurred.");
 

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -8,11 +8,10 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 fn generate_credential_bundle(
     identity: Vec<u8>,
-    credential_type: CredentialType,
     signature_algorithm: SignatureScheme,
     backend: &impl OpenMlsCryptoProvider,
 ) -> Result<Credential, CredentialError> {
-    let cb = CredentialBundle::new(identity, credential_type, signature_algorithm, backend)?;
+    let cb = CredentialBundle::new_basic(identity, signature_algorithm, backend)?;
     let credential = cb.credential().clone();
     backend
         .key_store()
@@ -79,7 +78,6 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
         // Generate credential bundles
         let alice_credential = generate_credential_bundle(
             "Alice".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )
@@ -87,7 +85,6 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
 
         let bob_credential = generate_credential_bundle(
             "Bob".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )
@@ -95,7 +92,6 @@ fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
 
         let charlie_credential = generate_credential_bundle(
             "Charlie".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )
@@ -917,7 +913,6 @@ fn test_empty_input_errors(ciphersuite: Ciphersuite, backend: &impl OpenMlsCrypt
     // Generate credential bundles
     let alice_credential = generate_credential_bundle(
         "Alice".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -972,7 +967,6 @@ fn mls_group_ratchet_tree_extension(
         // Generate credential bundles
         let alice_credential = generate_credential_bundle(
             "Alice".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )
@@ -980,7 +974,6 @@ fn mls_group_ratchet_tree_extension(
 
         let bob_credential = generate_credential_bundle(
             "Bob".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )
@@ -1028,7 +1021,6 @@ fn mls_group_ratchet_tree_extension(
         // Generate credential bundles
         let alice_credential = generate_credential_bundle(
             "Alice".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )
@@ -1036,7 +1028,6 @@ fn mls_group_ratchet_tree_extension(
 
         let bob_credential = generate_credential_bundle(
             "Bob".into(),
-            CredentialType::Basic,
             ciphersuite.signature_algorithm(),
             backend,
         )


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

In order to progress, fake x509 certificate. This will probably not be merged upstream. BUT it has:
* x509 certificate chain support
* validates certificates validity in time `not_before` & `not_after`
* validates certificates structures i.e. fields are correct
* verifies signature within the chain e.g. that chain[n] has been signed by chain[n+1]

BUT still lacks:
* identity getter for certificate (which fields in a certificate can be composed into an identity key)
* ciphersuite inference (defaults to default one in core-crypto i.e. Ed25519)

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
