### PR TITLE
support leaving a group and commit others removal [CL-37]

### DIFF
--- a/openmls/src/ciphersuite/hash_ref.rs
+++ b/openmls/src/ciphersuite/hash_ref.rs
@@ -32,16 +32,7 @@ type Value = [u8; VALUE_LEN];
 
 /// A reference to an MLS object computed as an HKDF of the value.
 #[derive(
-    Clone,
-    Copy,
-    Hash,
-    PartialEq,
-    Eq,
-    TlsDeserialize,
-    TlsSerialize,
-    TlsSize,
-    PartialOrd,
-    Ord,
+    Clone, Copy, Hash, PartialEq, Eq, TlsDeserialize, TlsSerialize, TlsSize, PartialOrd, Ord,
 )]
 pub struct HashReference {
     value: Value,
@@ -113,18 +104,20 @@ impl core::fmt::Debug for HashReference {
 impl serde::Serialize for HashReference {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer {
+        S: serde::Serializer,
+    {
         let str = hex::encode(&self.value);
         serializer.serialize_str(&str)
     }
 }
 
-impl <'de>serde::Deserialize<'de> for HashReference {
+impl<'de> serde::Deserialize<'de> for HashReference {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de> {
+        D: serde::Deserializer<'de>,
+    {
         struct HashVisitor;
-        impl <'de> serde::de::Visitor<'de> for HashVisitor {
+        impl<'de> serde::de::Visitor<'de> for HashVisitor {
             type Value = HashReference;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -132,8 +125,9 @@ impl <'de>serde::Deserialize<'de> for HashReference {
             }
 
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-                where
-                    E: serde::de::Error, {
+            where
+                E: serde::de::Error,
+            {
                 let mut buf = [0u8; 16];
                 hex::decode_to_slice(v, &mut buf).map_err(serde::de::Error::custom)?;
                 Ok(HashReference { value: buf })
@@ -157,9 +151,12 @@ mod serialization_tests {
     #[test]
     fn test_serialization() {
         let hash = HashReference {
-            value: b"Hello I'm Alice!".to_owned()
+            value: b"Hello I'm Alice!".to_owned(),
         };
-        assert_eq!(serde_json::to_value(&hash).unwrap(), serde_json::Value::String("48656c6c6f2049276d20416c69636521".to_owned()));
+        assert_eq!(
+            serde_json::to_value(&hash).unwrap(),
+            serde_json::Value::String("48656c6c6f2049276d20416c69636521".to_owned())
+        );
     }
 
     #[test]
@@ -171,9 +168,11 @@ mod serialization_tests {
 
     #[test]
     fn test_map_serialization() {
-        let mut test_map = MapTest { map: HashMap::new() };
+        let mut test_map = MapTest {
+            map: HashMap::new(),
+        };
         let hash = HashReference {
-            value: b"Hello I'm Alice!".to_owned()
+            value: b"Hello I'm Alice!".to_owned(),
         };
         test_map.map.insert(hash, "value".to_owned());
         let expected = serde_json::json!({
@@ -192,7 +191,7 @@ mod serialization_tests {
             }
         });
         let hash = HashReference {
-            value: b"Hello I'm Alice!".to_owned()
+            value: b"Hello I'm Alice!".to_owned(),
         };
         let result: MapTest = serde_json::from_value(input).unwrap();
         assert_eq!(result.map[&hash], "value");

--- a/openmls/src/group/core_group/apply_proposals.rs
+++ b/openmls/src/group/core_group/apply_proposals.rs
@@ -9,7 +9,7 @@ use crate::{
     group::errors::ApplyProposalsError,
     key_packages::KeyPackageBundle,
     messages::proposals::{AddProposal, Proposal, ProposalType},
-    schedule::{psk::*, InitSecret},
+    schedule::InitSecret,
     treesync::{diff::TreeSyncDiff, node::leaf_node::LeafNode},
 };
 

--- a/openmls/src/group/core_group/create_commit.rs
+++ b/openmls/src/group/core_group/create_commit.rs
@@ -2,9 +2,7 @@ use openmls_traits::OpenMlsCryptoProvider;
 
 use crate::{
     ciphersuite::signable::Signable,
-    framing::*,
-    group::{core_group::*, errors::CreateCommitError, *},
-    messages::*,
+    group::{core_group::*, errors::CreateCommitError},
     treesync::{
         diff::TreeSyncDiff,
         node::parent_node::PlainUpdatePathNode,

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -5,10 +5,8 @@ use tls_codec::Deserialize;
 use crate::{
     ciphersuite::{hash_ref::HashReference, signable::Verifiable},
     extensions::ExtensionType,
-    group::{core_group::*, errors::WelcomeError, *},
-    key_packages::*,
-    messages::*,
-    schedule::{errors::PskError, *},
+    group::{core_group::*, errors::WelcomeError},
+    schedule::errors::PskError,
     treesync::{errors::TreeSyncFromNodesError, node::Node},
 };
 

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -405,7 +405,7 @@ pub(crate) enum StagedCommitState {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StagedCommit {
     staged_proposal_queue: ProposalQueue,
-    state: StagedCommitState,
+    pub(crate) state: StagedCommitState,
     commit_update_key_package: Option<KeyPackage>,
 }
 
@@ -460,9 +460,9 @@ impl StagedCommit {
 /// This struct is used internally by [StagedCommit] to encapsulate all the modified group state.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct MemberStagedCommitState {
-    group_context: GroupContext,
+    pub(crate) group_context: GroupContext,
     group_epoch_secrets: GroupEpochSecrets,
-    message_secrets: MessageSecrets,
+    pub(crate) message_secrets: MessageSecrets,
     interim_transcript_hash: Vec<u8>,
     staged_diff: StagedTreeSyncDiff,
 }

--- a/openmls/src/group/core_group/test_duplicate_extension.rs
+++ b/openmls/src/group/core_group/test_duplicate_extension.rs
@@ -2,12 +2,13 @@
 use super::*;
 
 use crate::{
-    credentials::*, group::core_group::create_commit_params::CreateCommitParams,
-    group::errors::WelcomeError, messages::GroupSecrets, schedule::KeySchedule, test_utils::*,
+    group::{core_group::create_commit_params::CreateCommitParams, errors::WelcomeError},
+    messages::GroupSecrets,
+    schedule::KeySchedule,
+    test_utils::*,
 };
 use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::crypto::OpenMlsCrypto;
-use openmls_traits::OpenMlsCryptoProvider;
+use openmls_traits::{crypto::OpenMlsCrypto, OpenMlsCryptoProvider};
 use tls_codec::Deserialize;
 
 // This tests the ratchet tree extension to test if the duplicate detection works

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -206,6 +206,15 @@ pub enum LeaveGroupError {
     /// See [`MlsGroupStateError`] for more details.
     #[error(transparent)]
     GroupStateError(#[from] MlsGroupStateError),
+    /// Tried to commit a self removal in a leave operation
+    #[error("Tried to commit a self removal in a leave operation")]
+    AttemptToRemoveSelf,
+    /// Could not find a KeyPackage for removing self from group
+    #[error("Could not find a KeyPackage for removing self from group")]
+    NoKeyPackageForSelf,
+    /// See [`RemoveMembersError`] for more details.
+    #[error(transparent)]
+    RemoveMembersError(#[from] RemoveMembersError),
 }
 
 /// Self update error

--- a/openmls/src/group/mls_group/leave.rs
+++ b/openmls/src/group/mls_group/leave.rs
@@ -1,0 +1,158 @@
+//! MLS group membership leave
+//!
+
+use std::borrow::BorrowMut;
+
+use tls_codec::Serialize;
+
+use crate::prelude::CreateCommitError;
+use crate::{ciphersuite::hash_ref::KeyPackageRef, group::staged_commit::StagedCommitState};
+
+use super::{errors::LeaveGroupError, *};
+
+impl MlsGroup {
+    /// Leave the group.
+    ///
+    /// Creates a Remove Proposal that needs to be covered by a Commit from a different member.
+    /// The Remove Proposal is returned as a [`MlsMessageOut`].
+    ///
+    /// Returns an error if there is a pending commit.
+    pub async fn leave_group(
+        &mut self,
+        backend: &impl OpenMlsCryptoProvider,
+    ) -> Result<MlsMessageOut, LeaveGroupError> {
+        self.is_operational()?;
+
+        let credential_bundle: CredentialBundle = backend
+            .key_store()
+            .read(
+                &self
+                    .credential()?
+                    .signature_key()
+                    .tls_serialize_detached()
+                    .map_err(LibraryError::missing_bound_check)?,
+            )
+            .await
+            .ok_or(LeaveGroupError::NoMatchingCredentialBundle)?;
+
+        let removed = self
+            .group
+            .key_package_ref()
+            .ok_or_else(|| LibraryError::custom("No key package reference for own key package."))?;
+        let remove_proposal = self.group.create_remove_proposal(
+            self.framing_parameters(),
+            &credential_bundle,
+            removed,
+            backend,
+        )?;
+
+        self.proposal_store.add(QueuedProposal::from_mls_plaintext(
+            self.ciphersuite(),
+            backend,
+            remove_proposal.clone(),
+        )?);
+
+        Ok(self.plaintext_to_mls_message(remove_proposal, backend)?)
+    }
+
+    /// Extends [`leave_group`] by allowing to also remove other members in a commit
+    ///
+    /// Creates a commit for removing the other members.
+    /// Then creates a Remove Proposal for self that needs to be covered by a Commit from a different member.
+    ///
+    /// Once merging the commit, the sender must take care of restoring the proposal from the store.
+    /// Indeed, this restoring logic might depend upon implementer delivery semantics guaranteed by
+    /// its Delivery Service. For example, it might have to also restore proposals by reference in the store
+    /// in case its DS does not guarantees message ordering.
+    ///
+    /// Returns (SelfRemoveProposal, OthersRemoveCommit)
+    /// Returns an error if there is a pending commit.
+    pub async fn leave_group_and_remove_others(
+        &mut self,
+        backend: &impl OpenMlsCryptoProvider,
+        members: &[KeyPackageRef],
+    ) -> Result<(MlsMessageOut, MlsMessageOut), LeaveGroupError> {
+        self.is_operational()?;
+
+        let credential_bundle: CredentialBundle = backend
+            .key_store()
+            .read(
+                &self
+                    .credential()?
+                    .signature_key()
+                    .tls_serialize_detached()
+                    .map_err(LibraryError::missing_bound_check)?,
+            )
+            .await
+            .ok_or(LeaveGroupError::NoMatchingCredentialBundle)?;
+
+        // Let's create a commit without (potentially) encrypting it. We will need it later on
+        // to create a Remove Proposal for self with the new epoch secrets
+        let mut commit_result = self
+            .create_remove_commit(backend, members)
+            .await
+            .map_err(|e| match e {
+                RemoveMembersError::CreateCommitError(CreateCommitError::CannotRemoveSelf) => {
+                    LeaveGroupError::AttemptToRemoveSelf
+                }
+                _ => e.into(),
+            })?;
+
+        // if the sender KeyPackage changed during commit
+        let self_kpr_from_commit = commit_result
+            .staged_commit
+            .commit_update_key_package()
+            .map(|k| k.hash_ref(backend.crypto()))
+            .transpose()
+            .map_err(LeaveGroupError::LibraryError)?;
+        // else there's no UpdatePath and the KeyPackage is unchanged
+        let self_kpr = self_kpr_from_commit
+            .as_ref()
+            .or_else(|| self.group.key_package_ref())
+            .ok_or(LeaveGroupError::NoKeyPackageForSelf)?;
+
+        let staged_commit_state = match commit_result.staged_commit.state.borrow_mut() {
+            StagedCommitState::GroupMember(state) => state,
+            StagedCommitState::SelfRemoved(_) => return Err(LeaveGroupError::AttemptToRemoveSelf),
+        };
+
+        // Now we create a Remove Proposal for self. This proposal will have to be committed by
+        // another member of the group.
+        // We use the previous commit to create the proposal so that it remains valid if the commit gets merged
+        let self_remove_proposal = MlsPlaintext::member_proposal(
+            self.framing_parameters(),
+            self_kpr,
+            Proposal::Remove(RemoveProposal { removed: *self_kpr }),
+            &credential_bundle,
+            &staged_commit_state.group_context,
+            staged_commit_state.message_secrets.membership_key(),
+            backend,
+        )?;
+
+        let proposal_msg = self.plaintext_to_mls_message_for_new_epoch(
+            self_remove_proposal.clone(),
+            Some(&staged_commit_state.group_context),
+            Some(&mut staged_commit_state.message_secrets),
+            backend,
+        )?;
+
+        // Stores the proposal in the store but it will have to be manually restored after
+        // 'merge_pending_commit' which clears the store
+        self.proposal_store.add(QueuedProposal::from_mls_plaintext(
+            self.ciphersuite(),
+            backend,
+            self_remove_proposal.clone(),
+        )?);
+
+        // Now finish wrapping the commit in a message
+        let commit = self.plaintext_to_mls_message(commit_result.commit, backend)?;
+        self.group_state = MlsGroupState::PendingCommit(Box::new(PendingCommitState::Member(
+            commit_result.staged_commit,
+        )));
+
+        // Since the state of the group might be changed, arm the state flag
+        self.flag_state_change();
+
+        Ok((proposal_msg, commit))
+    }
+}

--- a/openmls/src/group/tests/kat_messages.rs
+++ b/openmls/src/group/tests/kat_messages.rs
@@ -4,6 +4,12 @@
 //! See <https://github.com/mlswg/mls-implementations/blob/master/test-vectors.md>
 //! for more description on the test vectors.
 
+use openmls_rust_crypto::OpenMlsRustCrypto;
+use openmls_traits::{random::OpenMlsRand, types::SignatureScheme, OpenMlsCryptoProvider};
+use serde::{self, Deserialize, Serialize};
+use thiserror::Error;
+use tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize, TlsSliceU32, TlsVecU32};
+
 use crate::{
     ciphersuite::signable::Signable,
     credentials::*,
@@ -20,12 +26,6 @@ use crate::{
     treesync::node::Node,
     versions::ProtocolVersion,
 };
-
-use openmls_rust_crypto::OpenMlsRustCrypto;
-use openmls_traits::{random::OpenMlsRand, types::SignatureScheme, OpenMlsCryptoProvider};
-use serde::{self, Deserialize, Serialize};
-use thiserror::Error;
-use tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize, TlsSliceU32, TlsVecU32};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct MessagesTestVector {

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -1,23 +1,32 @@
 //! This module tests the classification of remove operations with RemoveOperation
 
-use super::utils::{generate_credential_bundle, generate_key_package_bundle};
-use crate::{credentials::*, framing::*, group::*, test_utils::*, *};
 use openmls_rust_crypto::OpenMlsRustCrypto;
 
-// Tests the differen variants of the RemoveOperation enum.
+use crate::{credentials::*, framing::*, group::*, prelude::LeaveGroupError, test_utils::*, *};
+
+use super::utils::{generate_credential_bundle, generate_key_package_bundle};
+
+// Tests the different variants of the RemoveOperation enum.
 #[apply(ciphersuites_and_backends)]
 async fn test_remove_operation_variants(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
-    // We define two test cases, one where the member is removed by another member
-    // and one where the member leaves the group on its own
+    // We define three test cases:
+    // - one where the member is removed by another member
+    // - one where the member leaves the group on its own
+    // - one where the member leaves the group on its own and also removes others
     enum TestCase {
         Remove,
         Leave,
+        LeaveAndRemoveOthers,
     }
 
-    for test_case in [TestCase::Remove, TestCase::Leave] {
+    for test_case in [
+        TestCase::Remove,
+        TestCase::Leave,
+        TestCase::LeaveAndRemoveOthers,
+    ] {
         let group_id = GroupId::from_slice(b"Test Group");
 
         // Generate credential bundles
@@ -111,11 +120,14 @@ async fn test_remove_operation_variants(
         let alice_kpr = *alice_group
             .key_package_ref()
             .expect("An unexpected error occurred.");
-        let bob_kpr = *bob_group
+        let mut bob_kpr = *bob_group
+            .key_package_ref()
+            .expect("An unexpected error occurred.");
+        let charlie_kpr = *charlie_group
             .key_package_ref()
             .expect("An unexpected error occurred.");
 
-        // We differentiate between the two test cases here
+        // We differentiate between the three test cases here
         let (message, _welcome) = match test_case {
             // Alice removes Bob
             TestCase::Remove => alice_group
@@ -154,6 +166,87 @@ async fn test_remove_operation_variants(
                     .await
                     .expect("An unexpected error occurred.")
             }
+            // Bob leaves and removes Charlie
+            TestCase::LeaveAndRemoveOthers => {
+                // Bob cannot remove himself in a commit
+                let bob_tries_to_remove_self = bob_group
+                    .leave_group_and_remove_others(backend, &[bob_kpr])
+                    .await;
+                assert_eq!(
+                    bob_tries_to_remove_self.unwrap_err(),
+                    LeaveGroupError::AttemptToRemoveSelf
+                );
+
+                // Bob leaves the group and also removes Charlie
+                let (bob_remove_proposal, charlie_remove_commit) = bob_group
+                    .leave_group_and_remove_others(backend, &[charlie_kpr])
+                    .await
+                    .expect("Could not leave group.");
+
+                // Proposal must be for next epoch
+                assert_eq!(
+                    charlie_remove_commit.epoch().as_u64() + 1,
+                    bob_remove_proposal.epoch().as_u64()
+                );
+
+                // Alice & Charlie process the commit
+                for group in [&mut alice_group, &mut charlie_group] {
+                    let unverified_message = group
+                        .parse_message(charlie_remove_commit.clone().into(), backend)
+                        .expect("Could not parse message.");
+                    let processed_message = group
+                        .process_unverified_message(unverified_message, None, backend)
+                        .await
+                        .expect("Could not process unverified message.");
+
+                    match processed_message {
+                        ProcessedMessage::StagedCommitMessage(commit) => {
+                            group.merge_staged_commit(*commit).unwrap();
+                        }
+                        _ => unreachable!(),
+                    }
+                }
+
+                // Charlie is no longer active
+                assert!(!charlie_group.is_active());
+
+                // Manually restore proposals in Bob's store
+                let previous_bob_proposals =
+                    bob_group.pending_proposals().cloned().collect::<Vec<_>>();
+                bob_group.merge_pending_commit().unwrap();
+
+                // Later used and since Bob merged the commit removing Charlie, Bob's KeyPackage
+                // is likely to have changed
+                bob_kpr = *bob_group.key_package_ref().unwrap();
+
+                // Charlie is no longer in the group
+                assert_eq!(bob_group.members().len(), 2);
+                previous_bob_proposals
+                    .into_iter()
+                    .for_each(|p| bob_group.store_pending_proposal(p));
+
+                // Alice store the pending proposal
+                let unverified_message = alice_group
+                    .parse_message(bob_remove_proposal.clone().into(), backend)
+                    .expect("Could not parse message.");
+                let processed_message = alice_group
+                    .process_unverified_message(unverified_message, None, backend)
+                    .await
+                    .expect("Could not process unverified message.");
+
+                match processed_message {
+                    ProcessedMessage::ProposalMessage(proposal) => {
+                        alice_group.store_pending_proposal(*proposal);
+                    }
+                    _ => unreachable!(),
+                }
+
+                // Alice commits to Bob's proposal
+                alice_group
+                    .commit_to_pending_proposals(backend)
+                    .await
+                    .expect("An unexpected error occurred.")
+            }
         };
 
         // === Remove operation from Alice's perspective ===
@@ -179,7 +272,7 @@ async fn test_remove_operation_variants(
                     _ => unreachable!(),
                 }
             }
-            TestCase::Leave => {
+            TestCase::Leave | TestCase::LeaveAndRemoveOthers => {
                 // We expect this variant, since Bob left
                 match remove_operation {
                     RemoveOperation::TheyLeft(removed) => {
@@ -231,7 +324,7 @@ async fn test_remove_operation_variants(
                             _ => unreachable!(),
                         }
                     }
-                    TestCase::Leave => {
+                    TestCase::Leave | TestCase::LeaveAndRemoveOthers => {
                         // We expect this variant, since Bob left
                         match remove_operation {
                             RemoveOperation::WeLeft => {
@@ -248,57 +341,67 @@ async fn test_remove_operation_variants(
 
         // === Remove operation from Charlie's perspective ===
 
-        let unverified_message = charlie_group
-            .parse_message(message.into(), backend)
-            .expect("Could not parse message.");
-        let charlie_processed_message = charlie_group
-            .process_unverified_message(unverified_message, None, backend)
-            .await
-            .expect("Could not process unverified message.");
+        match test_case {
+            TestCase::Remove | TestCase::Leave => {
+                let unverified_message = charlie_group
+                    .parse_message(message.into(), backend)
+                    .expect("Could not parse message.");
+                let charlie_processed_message = charlie_group
+                    .process_unverified_message(unverified_message, None, backend)
+                    .await
+                    .expect("Could not process unverified message.");
 
-        match charlie_processed_message {
-            ProcessedMessage::StagedCommitMessage(charlie_staged_commit) => {
-                let remove_proposal = charlie_staged_commit
-                    .remove_proposals()
-                    .next()
-                    .expect("An unexpected error occurred.");
+                match charlie_processed_message {
+                    ProcessedMessage::StagedCommitMessage(charlie_staged_commit) => {
+                        let remove_proposal = charlie_staged_commit
+                            .remove_proposals()
+                            .next()
+                            .expect("An unexpected error occurred.");
 
-                let remove_operation = RemoveOperation::new(remove_proposal, &charlie_group)
-                    .expect("An unexpected Error occurred.");
+                        let remove_operation =
+                            RemoveOperation::new(remove_proposal, &charlie_group)
+                                .expect("An unexpected Error occurred.");
 
-                match test_case {
-                    TestCase::Remove => {
-                        // We expect this variant, since Alice removed Bob
-                        match remove_operation {
-                            RemoveOperation::TheyWereRemovedBy((removed, sender)) => {
-                                // Make sure Alice is indeed a member
-                                assert!(sender.is_member());
-                                // Check that it was indeed Bob who was removed
-                                assert_eq!(removed, bob_kpr);
-                                match sender {
-                                    Sender::Member(member) => {
-                                        // Check that it was Alice who removed Bob
-                                        assert_eq!(member, alice_kpr);
+                        match test_case {
+                            TestCase::Remove => {
+                                // We expect this variant, since Alice removed Bob
+                                match remove_operation {
+                                    RemoveOperation::TheyWereRemovedBy((removed, sender)) => {
+                                        // Make sure Alice is indeed a member
+                                        assert!(sender.is_member());
+                                        // Check that it was indeed Bob who was removed
+                                        assert_eq!(removed, bob_kpr);
+                                        match sender {
+                                            Sender::Member(member) => {
+                                                // Check that it was Alice who removed Bob
+                                                assert_eq!(member, alice_kpr);
+                                            }
+                                            _ => unreachable!(),
+                                        }
                                     }
                                     _ => unreachable!(),
                                 }
                             }
-                            _ => unreachable!(),
-                        }
-                    }
-                    TestCase::Leave => {
-                        // We expect this variant, since Bob left
-                        match remove_operation {
-                            RemoveOperation::TheyLeft(removed) => {
-                                // Check that it was indeed Bob who left
-                                assert_eq!(removed, bob_kpr);
+                            TestCase::Leave => {
+                                // We expect this variant, since Bob left
+                                match remove_operation {
+                                    RemoveOperation::TheyLeft(removed) => {
+                                        // Check that it was indeed Bob who left
+                                        assert_eq!(removed, bob_kpr);
+                                    }
+                                    _ => unreachable!(),
+                                }
                             }
-                            _ => unreachable!(),
+                            TestCase::LeaveAndRemoveOthers => unreachable!(),
                         }
                     }
+                    _ => unreachable!(),
                 }
             }
-            _ => unreachable!(),
+            TestCase::LeaveAndRemoveOthers => {
+                // In this scenario Charlie's group is already inactive
+                assert!(!charlie_group.is_active());
+            }
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

To reduce back and forth between Wire client and core-crypto, we allow a user (and all its clients) to leave a group within a single method call. To do so, we commit user's other clients removal and create a Remove Proposal for the sender. The challenge here is to create the proposal for the sender since we also create a commit which is unmerged.

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
