### PR TITLE
Adding mutable lifetime access to extension in keypackage to help tests

### DIFF
--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -290,6 +290,18 @@ impl Extension {
         }
     }
 
+    /// Returns a mutable reference to lifetime extensions.
+    /// Intended to help testing
+    #[cfg(any(feature = "test-utils", test))]
+    pub fn as_mut_lifetime_extension(&mut self) -> Result<&mut LifetimeExtension, ExtensionError> {
+        match self {
+            Self::LifeTime(e) => Ok(e),
+            _ => Err(ExtensionError::InvalidExtensionType(
+                "This is not a LifetimeExtension".into(),
+            )),
+        }
+    }
+
     /// Get a reference to this extension as [`ExternalKeyIdExtension`].
     /// Returns an [`ExtensionError::InvalidExtensionType`] if called on an
     /// [`Extension`] that's not an [`ExternalKeyIdExtension`].

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -302,6 +302,25 @@ impl KeyPackage {
         self.payload.extensions.as_slice()
     }
 
+    /// Get a reference to the extensions of this key package.
+    ///
+    /// # Panics
+    /// It will panic if the LifetimeExtension is not present, but it is required so it shouldn't
+    /// happen
+    #[cfg(any(feature = "test-utils", test))]
+    pub fn mut_lifetime(&mut self) -> &mut LifetimeExtension {
+        let mut index = -1;
+        for (i, extension) in self.payload.extensions.iter.enumerate() {
+            if extension.extension_type() == ExtensionType::Lifetime {
+                index = i;
+                break;
+            }
+        }
+        &mut self.payload.extensions[index]
+            .as_mut_lifetime_extension()
+            .expect("Not lifetime extension")
+    }
+
     /// Check whether the this key package supports all the required extensions
     /// in the provided list.
     pub fn check_extension_support(


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR intends to provide mutable access to the lifetime extension inside the `KeyPackage` in order to help test features.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
