### PR TITLE
fix: support EC signatures while verifying x509 certificate chain [CL-153]

### DIFF
--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -38,7 +38,7 @@ hex = "0.4"
 [dependencies.x509-parser]
 git = "https://github.com/wireapp/x509-parser"
 tag = "v1.0.2-pre.core-crypto-0.6.0"
-features = ["verify", "validate"]
+features = ["validate"]
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rayon = "^1.5.0"

--- a/openmls/src/ciphersuite/signature.rs
+++ b/openmls/src/ciphersuite/signature.rs
@@ -12,6 +12,14 @@ pub struct Signature {
     value: TlsByteVecU16,
 }
 
+impl From<Vec<u8>> for Signature {
+    fn from(value: Vec<u8>) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
+}
+
 /// A private signature key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(any(feature = "test-utils", test), derive(PartialEq))]

--- a/openmls/src/messages/external_proposals.rs
+++ b/openmls/src/messages/external_proposals.rs
@@ -4,16 +4,17 @@
 //! to add a client from a MLS group
 //! `Remove` & `ReInit are nto yet implemented`
 
+use openmls_traits::OpenMlsCryptoProvider;
+
 use crate::{
     credentials::CredentialBundle,
     error::LibraryError,
-    framing::{FramingParameters, MlsMessageOut, MlsPlaintext, Sender, WireFormat},
+    framing::{MlsMessageOut, MlsPlaintext, Sender},
     group::{mls_group::errors::ProposeAddMemberError, GroupEpoch, GroupId},
     key_packages::KeyPackage,
     messages::{AddProposal, Proposal, RemoveProposal},
     prelude::KeyPackageRef,
 };
-use openmls_traits::OpenMlsCryptoProvider;
 
 /// External Proposal.
 /// External proposal allows parties outside a group to request changes to the latter.


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Stop relying on ring for verifying certificate chain since it does not support EcDSA on WASM. This verifies a x509 certificate signature with openmls CryptoProvider instead

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
