### PR TITLE
feat: Implement x509 credentials support - CL-171

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ members = [
     "memory_keystore",
     "delivery-service/ds",
     "delivery-service/ds-lib",
-    "basic_credential"
+    "basic_credential",
+    "x509_credential"
 ]
 resolver = "2"
 

--- a/book/src/user_manual/identity.md
+++ b/book/src/user_manual/identity.md
@@ -15,11 +15,10 @@ Note that the implementation of the Authentication Service and, thus, the detail
 ## Creating and using credentials
 
 OpenMLS allows clients to create `Credentials`.
-A `BasicCredential`, currently the only credential type supported by OpenMLS, consists only of the `identity`.
-Thus, to create a fresh `Credential`, the following inputs are required:
+A `BasicCredential`, consists only of the `identity`.
+Thus, to create a fresh `Credential`, the following input is required:
 
 - `identity: Vec<u8>`: An octet string that uniquely identifies the client.
-- `credential_type: CredentialType`: The type of the credential, in this case `CredentialType::Basic`.
 
 ```rust,no_run,noplayground
 {{#include ../../../openmls/tests/book_code.rs:create_basic_credential}}

--- a/cli/src/identity.rs
+++ b/cli/src/identity.rs
@@ -15,7 +15,7 @@ impl Identity {
         crypto: &OpenMlsRustCrypto,
         id: &[u8],
     ) -> Self {
-        let credential = Credential::new(id.to_vec(), CredentialType::Basic).unwrap();
+        let credential = Credential::new_basic(id.to_vec());
         let signature_keys = SignatureKeyPair::new(
             ciphersuite.signature_algorithm(),
             &mut *crypto.rand().borrow_rand().unwrap(),

--- a/delivery-service/ds-lib/tests/test_codec.rs
+++ b/delivery-service/ds-lib/tests/test_codec.rs
@@ -11,8 +11,7 @@ async fn test_client_info() {
     let client_name = "Client1";
     let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 
-    let credential =
-        Credential::new(client_name.as_bytes().to_vec(), CredentialType::Basic).unwrap();
+    let credential = Credential::new_basic(client_name.as_bytes().to_vec());
     let signature_keys = SignatureKeyPair::new(
         ciphersuite.signature_algorithm(),
         &mut *crypto.rand().borrow_rand().unwrap(),

--- a/delivery-service/ds/src/test.rs
+++ b/delivery-service/ds/src/test.rs
@@ -12,7 +12,7 @@ fn generate_credential(
     signature_scheme: SignatureScheme,
     crypto_backend: &impl OpenMlsCryptoProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
-    let credential = Credential::new(identity, CredentialType::Basic).unwrap();
+    let credential = Credential::new_basic(identity);
     let signature_keys = SignatureKeyPair::new(
         signature_scheme,
         &mut *crypto_backend.rand().borrow_rand().unwrap(),

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -25,9 +25,11 @@ serde_json = { version = "1.0", optional = true }
 itertools = { version = "0.10", optional = true }
 openmls_rust_crypto = { version = "0.1.0", path = "../openmls_rust_crypto", optional = true }
 openmls_basic_credential = { version = "0.1.0", path = "../basic_credential", optional = true, features = ["clonable", "test-utils"] }
+openmls_x509_credential = { version = "0.1.0", path = "../x509_credential", optional = true, features = ["test-utils"] }
 rstest = { version = "^0.16", optional = true }
 rstest_reuse = { version = "0.4", optional = true }
 tokio = { version = "1.24", features = ["full"], optional = true }
+x509-cert = "0.2"
 
 [features]
 default = []
@@ -41,6 +43,7 @@ test-utils = [
     "dep:rstest",
     "dep:rstest_reuse",
     "dep:openmls_basic_credential",
+    "dep:openmls_x509_credential",
 ]
 crypto-debug = [] # ☣️ Enable logging of sensitive cryptographic information
 content-debug = [] # ☣️ Enable logging of sensitive message content

--- a/openmls/benches/benchmark.rs
+++ b/openmls/benches/benchmark.rs
@@ -9,7 +9,7 @@ use openmls_traits::{crypto::OpenMlsCrypto, OpenMlsCryptoProvider};
 fn criterion_benchmark(c: &mut Criterion) {
     let backend = OpenMlsRustCrypto::default();
     for &ciphersuite in backend.crypto().supported_ciphersuites().iter() {
-        let credential = Credential::new(vec![1, 2, 3], CredentialType::Basic).unwrap();
+        let credential = Credential::new_basic(vec![1, 2, 3]);
         let signer = SignatureKeyPair::new(
             ciphersuite.signature_algorithm(),
             &mut *backend.rand().borrow_rand().unwrap(),

--- a/openmls/src/credentials/errors.rs
+++ b/openmls/src/credentials/errors.rs
@@ -17,4 +17,13 @@ pub enum CredentialError {
     /// Verifying the signature with this credential failed.
     #[error("Invalid signature.")]
     InvalidSignature,
+    /// Incomplete x509 certificate chain
+    #[error("x509 certificate chain is either empty or contains a single self-signed certificate which is not allowed.")]
+    IncompleteCertificateChain,
+    /// Failed to decode certificate data
+    #[error("Failed to decode certificate data: {0}")]
+    CertificateDecodingError(#[from] x509_cert::der::Error),
+    /// x509 certificate chain is either unordered or a child is missigned by its issuer
+    #[error("Invalid x509 certificate chain.")]
+    InvalidCertificateChain,
 }

--- a/openmls/src/credentials/mod.rs
+++ b/openmls/src/credentials/mod.rs
@@ -35,6 +35,7 @@ mod codec;
 #[cfg(test)]
 mod tests;
 use errors::*;
+use x509_cert::{der::Decode, PkiPath};
 
 use crate::ciphersuite::SignaturePublicKey;
 
@@ -139,9 +140,24 @@ impl From<CredentialType> for u16 {
 ///     opaque cert_data<V>;
 /// } Certificate;
 /// ```
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsSerialize, TlsDeserialize, TlsSize,
+)]
 pub struct Certificate {
-    cert_data: Vec<u8>,
+    identity: VLBytes,
+    cert_data: Vec<VLBytes>,
+}
+
+impl Certificate {
+    pub(crate) fn pki_path(&self) -> Result<PkiPath, CredentialError> {
+        self.cert_data.iter().try_fold(
+            PkiPath::new(),
+            |mut acc, cert_data| -> Result<PkiPath, CredentialError> {
+                acc.push(x509_cert::Certificate::from_der(cert_data.as_slice())?);
+                Ok(acc)
+            },
+        )
+    }
 }
 
 /// MlsCredentialType.
@@ -184,27 +200,36 @@ impl Credential {
         self.credential_type
     }
 
-    /// Creates and returns a new [`Credential`] of the given
-    /// [`CredentialType`] for the given identity.
+    pub(crate) fn mls_credential(&self) -> &MlsCredentialType {
+        &self.credential
+    }
+
+    /// Creates and returns a new basic [`Credential`] for the given identity.
     /// If the credential holds key material, this is generated and stored in
     /// the key store.
-    ///
-    /// Returns an error if the given [`CredentialType`] is not supported.
-    pub fn new(
-        identity: Vec<u8>,
-        credential_type: CredentialType,
-    ) -> Result<Self, CredentialError> {
-        let mls_credential = match credential_type {
-            CredentialType::Basic => BasicCredential {
+    pub fn new_basic(identity: Vec<u8>) -> Self {
+        Self {
+            credential_type: CredentialType::Basic,
+            credential: MlsCredentialType::Basic(BasicCredential {
                 identity: identity.into(),
-            },
-            _ => return Err(CredentialError::UnsupportedCredentialType),
-        };
-        let credential = Credential {
-            credential_type,
-            credential: MlsCredentialType::Basic(mls_credential),
-        };
-        Ok(credential)
+            }),
+        }
+    }
+
+    /// Creates and returns a new X509 [`Credential`] for the given identity.
+    /// If the credential holds key material, this is generated and stored in
+    /// the key store.
+    pub fn new_x509(identity: Vec<u8>, cert_data: Vec<Vec<u8>>) -> Result<Self, CredentialError> {
+        if cert_data.len() < 2 {
+            return Err(CredentialError::IncompleteCertificateChain);
+        }
+        Ok(Self {
+            credential_type: CredentialType::X509,
+            credential: MlsCredentialType::X509(Certificate {
+                identity: identity.into(),
+                cert_data: cert_data.into_iter().map(|c| c.into()).collect(),
+            }),
+        })
     }
 
     /// Returns the identity of a given credential.
@@ -212,7 +237,7 @@ impl Credential {
         match &self.credential {
             MlsCredentialType::Basic(basic_credential) => basic_credential.identity.as_slice(),
             // TODO: implement getter for identity for X509 certificates. See issue #134.
-            MlsCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
+            MlsCredentialType::X509(cred) => cred.identity.as_slice(),
         }
     }
 }
@@ -273,6 +298,27 @@ pub mod test_utils {
     use super::{Credential, CredentialType, CredentialWithKey};
 
     /// Convenience function that generates a new credential and a key pair for
+    /// it (using the x509 credential crate).
+    /// The signature keys are stored in the key store.
+    ///
+    /// Returns the [`Credential`] and the [`SignatureKeyPair`].
+    pub async fn new_x509_credential(
+        backend: &impl OpenMlsCryptoProvider,
+        identity: &[u8],
+        signature_scheme: SignatureScheme,
+        cert_data: Vec<Vec<u8>>,
+    ) -> (CredentialWithKey, SignatureKeyPair) {
+        build_credential(
+            backend,
+            identity,
+            CredentialType::X509,
+            signature_scheme,
+            Some(cert_data),
+        )
+        .await
+    }
+
+    /// Convenience function that generates a new credential and a key pair for
     /// it (using the basic credential crate).
     /// The signature keys are stored in the key store.
     ///
@@ -280,10 +326,32 @@ pub mod test_utils {
     pub async fn new_credential(
         backend: &impl OpenMlsCryptoProvider,
         identity: &[u8],
-        credential_type: CredentialType,
         signature_scheme: SignatureScheme,
     ) -> (CredentialWithKey, SignatureKeyPair) {
-        let credential = Credential::new(identity.into(), credential_type).unwrap();
+        build_credential(
+            backend,
+            identity,
+            CredentialType::Basic,
+            signature_scheme,
+            None,
+        )
+        .await
+    }
+
+    async fn build_credential(
+        backend: &impl OpenMlsCryptoProvider,
+        identity: &[u8],
+        credential_type: CredentialType,
+        signature_scheme: SignatureScheme,
+        cert_data: Option<Vec<Vec<u8>>>,
+    ) -> (CredentialWithKey, SignatureKeyPair) {
+        let credential = match credential_type {
+            CredentialType::Basic => Credential::new_basic(identity.into()),
+            CredentialType::X509 => {
+                Credential::new_x509(identity.into(), cert_data.unwrap()).unwrap()
+            }
+            CredentialType::Unknown(_) => unimplemented!(),
+        };
         let signature_keys = SignatureKeyPair::new(
             signature_scheme,
             &mut *backend.rand().borrow_rand().unwrap(),

--- a/openmls/src/extensions/external_sender_extension.rs
+++ b/openmls/src/extensions/external_sender_extension.rs
@@ -70,7 +70,7 @@ mod test {
     use tls_codec::{Deserialize, Serialize};
 
     use super::*;
-    use crate::{credentials::CredentialType, test_utils::*};
+    use crate::test_utils::*;
 
     #[apply(ciphersuites)]
     async fn test_serialize_deserialize(ciphersuite: Ciphersuite) {
@@ -79,7 +79,7 @@ mod test {
             let mut external_sender_extensions = Vec::new();
 
             for _ in 0..8 {
-                let credential = Credential::new(b"Alice".to_vec(), CredentialType::Basic).unwrap();
+                let credential = Credential::new_basic(b"Alice".to_vec());
                 let signature_keys =
                     SignatureKeyPair::new(ciphersuite.signature_algorithm(), &mut rng).unwrap();
 

--- a/openmls/src/extensions/test_extensions.rs
+++ b/openmls/src/extensions/test_extensions.rs
@@ -41,20 +41,10 @@ async fn ratchet_tree_extension(ciphersuite: Ciphersuite, backend: &impl OpenMls
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::PublicMessage);
 
     // Create credentials and keys
-    let (alice_credential_with_key, alice_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
-    let (bob_credential_with_key, bob_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Bob",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (alice_credential_with_key, alice_signature_keys) =
+        test_utils::new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
+    let (bob_credential_with_key, bob_signature_keys) =
+        test_utils::new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
     // Generate KeyPackages
     let bob_key_package_bundle = KeyPackageBundle::new(

--- a/openmls/src/framing/message_out.rs
+++ b/openmls/src/framing/message_out.rs
@@ -117,10 +117,7 @@ impl From<KeyPackage> for MlsMessageOut {
 impl MlsMessageOut {
     /// Create an [`MlsMessageOut`] from a [`PrivateMessage`], as well as the
     /// currently used [`ProtocolVersion`].
-    pub fn from_private_message(
-        private_message: PrivateMessage,
-        version: ProtocolVersion,
-    ) -> Self {
+    pub fn from_private_message(private_message: PrivateMessage, version: ProtocolVersion) -> Self {
         Self {
             version,
             body: MlsMessageOutBody::PrivateMessage(private_message),

--- a/openmls/src/framing/test_framing.rs
+++ b/openmls/src/framing/test_framing.rs
@@ -27,13 +27,8 @@ use crate::{
 /// This tests serializing/deserializing PublicMessage
 #[apply(ciphersuites_and_backends)]
 async fn codec_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let (_credential, signature_keys) = test_utils::new_credential(
-        backend,
-        b"Creator",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (_credential, signature_keys) =
+        test_utils::new_credential(backend, b"Creator", ciphersuite.signature_algorithm()).await;
     let sender = Sender::build_member(LeafNodeIndex::new(987543210));
     let group_context = GroupContext::new(
         ciphersuite,
@@ -80,13 +75,8 @@ async fn codec_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoP
 /// This tests serializing/deserializing PrivateMessage
 #[apply(ciphersuites_and_backends)]
 async fn codec_ciphertext(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let (_credential, signature_keys) = test_utils::new_credential(
-        backend,
-        b"Creator",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (_credential, signature_keys) =
+        test_utils::new_credential(backend, b"Creator", ciphersuite.signature_algorithm()).await;
     let sender = Sender::build_member(LeafNodeIndex::new(0));
     let group_context = GroupContext::new(
         ciphersuite,
@@ -297,13 +287,8 @@ async fn create_content(
     wire_format: WireFormat,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (AuthenticatedContent, CredentialWithKey, SignatureKeyPair) {
-    let (credential, signature_keys) = test_utils::new_credential(
-        backend,
-        b"Creator",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (credential, signature_keys) =
+        test_utils::new_credential(backend, b"Creator", ciphersuite.signature_algorithm()).await;
     let sender = Sender::build_member(LeafNodeIndex::new(0));
     let group_context = GroupContext::new(
         ciphersuite,
@@ -334,13 +319,8 @@ async fn create_content(
 
 #[apply(ciphersuites_and_backends)]
 async fn membership_tag(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let (_credential, signature_keys) = test_utils::new_credential(
-        backend,
-        b"Creator",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (_credential, signature_keys) =
+        test_utils::new_credential(backend, b"Creator", ciphersuite.signature_algorithm()).await;
     let group_context = GroupContext::new(
         ciphersuite,
         GroupId::random(backend),
@@ -396,27 +376,12 @@ async fn unknown_sender(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
     let configuration = &SenderRatchetConfiguration::default();
 
     // Define credentials with keys
-    let (alice_credential, alice_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
-    let (bob_credential, bob_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Bob",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
-    let (charlie_credential, charlie_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Charlie",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (alice_credential, alice_signature_keys) =
+        test_utils::new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
+    let (bob_credential, bob_signature_keys) =
+        test_utils::new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
+    let (charlie_credential, charlie_signature_keys) =
+        test_utils::new_credential(backend, b"Charlie", ciphersuite.signature_algorithm()).await;
 
     // Generate KeyPackages
     let bob_key_package_bundle =
@@ -651,20 +616,10 @@ pub(crate) async fn setup_alice_bob_group(
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::PublicMessage);
 
     // Create credentials and keys
-    let (alice_credential, alice_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
-    let (bob_credential, bob_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Bob",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (alice_credential, alice_signature_keys) =
+        test_utils::new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
+    let (bob_credential, bob_signature_keys) =
+        test_utils::new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
     // Generate KeyPackages
     let bob_key_package_bundle = KeyPackageBundle::new(

--- a/openmls/src/group/core_group/test_core_group.rs
+++ b/openmls/src/group/core_group/test_core_group.rs
@@ -29,13 +29,8 @@ pub(crate) async fn setup_alice_group(
     OpenMlsSignaturePublicKey,
 ) {
     // Create credentials and keys
-    let (alice_credential_with_key, alice_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (alice_credential_with_key, alice_signature_keys) =
+        test_utils::new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
     let pk = OpenMlsSignaturePublicKey::new(
         alice_signature_keys.to_public_vec().into(),
         ciphersuite.signature_algorithm(),
@@ -100,13 +95,8 @@ async fn test_failed_groupinfo_decryption(
     });
 
     // Create credentials and keys
-    let (alice_credential_with_key, alice_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (alice_credential_with_key, alice_signature_keys) =
+        test_utils::new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
 
     let key_package_bundle = KeyPackageBundle::new(
         backend,
@@ -320,20 +310,10 @@ async fn setup_alice_bob(
     SignatureKeyPair,
 ) {
     // Create credentials and keys
-    let (alice_credential_with_key, alice_signer) = test_utils::new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
-    let (bob_credential_with_key, bob_signer) = test_utils::new_credential(
-        backend,
-        b"Bob",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (alice_credential_with_key, alice_signer) =
+        test_utils::new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
+    let (bob_credential_with_key, bob_signer) =
+        test_utils::new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
     // Generate Bob's KeyPackage
     let bob_key_package_bundle =
@@ -562,13 +542,8 @@ async fn test_own_commit_processing(
     let framing_parameters = FramingParameters::new(group_aad, WireFormat::PublicMessage);
 
     // Create credentials and keys
-    let (alice_credential_with_key, alice_signature_keys) = test_utils::new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (alice_credential_with_key, alice_signature_keys) =
+        test_utils::new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
 
     // === Alice creates a group ===
     let alice_group = CoreGroup::builder(
@@ -612,13 +587,8 @@ pub(crate) async fn setup_client_with_extensions(
     SignatureKeyPair,
     OpenMlsSignaturePublicKey,
 ) {
-    let (credential_with_key, signature_keys) = test_utils::new_credential(
-        backend,
-        id.as_bytes(),
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (credential_with_key, signature_keys) =
+        test_utils::new_credential(backend, id.as_bytes(), ciphersuite.signature_algorithm()).await;
     let pk = OpenMlsSignaturePublicKey::new(
         signature_keys.to_public_vec().into(),
         ciphersuite.signature_algorithm(),

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -5,9 +5,11 @@
 
 // These errors are exposed through `crate::group::errors`.
 
+use openmls_traits::types::CryptoError;
 use thiserror::Error;
 
 use crate::{
+    credentials::errors::CredentialError,
     error::LibraryError,
     extensions::errors::{ExtensionError, InvalidExtensionError},
     group::errors::{
@@ -114,6 +116,12 @@ pub enum ProcessMessageError {
     /// The proposal is invalid for the Sender of type [External](crate::prelude::Sender::External)
     #[error("The proposal is invalid for the Sender of type External")]
     UnsupportedProposalType,
+    /// Error parsing the certificate chain
+    #[error("Error parsing the X509 certificate chain: {0}")]
+    CredentialError(#[from] CredentialError),
+    /// Error validating the certificate chain
+    #[error("Error validating certificate chain")]
+    CryptoError(#[from] CryptoError),
 }
 
 /// Create message error

--- a/openmls/src/group/mls_group/extension.rs
+++ b/openmls/src/group/mls_group/extension.rs
@@ -2,8 +2,6 @@
 //!
 //! Contains all the methods related to modifying a group's extensions.
 
-use std::iter;
-
 use openmls_traits::signatures::Signer;
 
 use crate::{

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -370,7 +370,7 @@ async fn test_valsem101a(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoP
             backend,
             &charlie_credential_with_key.signer,
             CredentialWithKey {
-                credential: Credential::new(b"Dave".to_vec(), CredentialType::Basic).unwrap(),
+                credential: Credential::new_basic(b"Dave".to_vec()),
                 signature_key: charlie_credential_with_key
                     .credential_with_key
                     .signature_key,
@@ -617,7 +617,7 @@ async fn test_valsem101b(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoP
             }
             .map(|(name, keypair)| CredentialWithKeyAndSigner {
                 credential_with_key: CredentialWithKey {
-                    credential: Credential::new(name.into(), CredentialType::Basic).unwrap(),
+                    credential: Credential::new_basic(name.into()),
                     signature_key: keypair.to_public_vec().into(),
                 },
                 signer: keypair,

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -344,7 +344,7 @@ pub(crate) async fn generate_credential_with_key(
     backend: &impl OpenMlsCryptoProvider,
 ) -> CredentialWithKeyAndSigner {
     let (credential, signer) = {
-        let credential = Credential::new(identity, CredentialType::Basic).unwrap();
+        let credential = Credential::new_basic(identity);
         let signature_keys = SignatureKeyPair::new(
             signature_scheme,
             &mut *backend.rand().borrow_rand().unwrap(),

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -37,7 +37,7 @@
 //! let ciphersuite = Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
 //! let backend = OpenMlsRustCrypto::default();
 //!
-//! let credential = Credential::new("identity".into(), CredentialType::Basic).unwrap();
+//! let credential = Credential::new_basic("identity".into());
 //! let signer =
 //!     SignatureKeyPair::new(ciphersuite.signature_algorithm(), &mut *backend.rand().borrow_rand().unwrap())
 //!         .expect("Error generating a signature key pair.");

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -11,7 +11,7 @@ pub(crate) async fn key_package(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (KeyPackage, Credential, SignatureKeyPair) {
-    let credential = Credential::new(b"Sasha".to_vec(), CredentialType::Basic).unwrap();
+    let credential = Credential::new_basic(b"Sasha".to_vec());
     let signer = SignatureKeyPair::new(
         ciphersuite.signature_algorithm(),
         &mut *backend.rand().borrow_rand().unwrap(),
@@ -65,8 +65,7 @@ async fn serialization(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPro
 
 #[apply(ciphersuites_and_backends)]
 async fn application_id_extension(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let credential = Credential::new(b"Sasha".to_vec(), CredentialType::Basic)
-        .expect("An unexpected error occurred.");
+    let credential = Credential::new_basic(b"Sasha".to_vec());
     let signature_keys = SignatureKeyPair::new(
         ciphersuite.signature_algorithm(),
         &mut *backend.rand().borrow_rand().unwrap(),

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -19,11 +19,10 @@
 //! // A helper to create and store credentials.
 //! async fn generate_credential_with_key(
 //!     identity: Vec<u8>,
-//!     credential_type: CredentialType,
 //!     signature_algorithm: SignatureScheme,
 //!     backend: &impl OpenMlsCryptoProvider,
 //! ) -> (CredentialWithKey, SignatureKeyPair) {
-//!     let credential = Credential::new(identity, credential_type).unwrap();
+//!     let credential = Credential::new_basic(identity);
 //!     let signature_keys =
 //!         SignatureKeyPair::new(signature_algorithm, &mut *backend.rand().borrow_rand().unwrap())
 //!             .expect("Error generating a signature key pair.");
@@ -72,14 +71,12 @@
 //!     // First they need credentials to identify them
 //!     let (sasha_credential_with_key, sasha_signer) = generate_credential_with_key(
 //!         "Sasha".into(),
-//!         CredentialType::Basic,
 //!         ciphersuite.signature_algorithm(),
 //!         backend,
 //!     ).await;
 //!
 //!     let (maxim_credential_with_key, maxim_signer) = generate_credential_with_key(
 //!         "Maxim".into(),
-//!         CredentialType::Basic,
 //!         ciphersuite.signature_algorithm(),
 //!         backend,
 //!     ).await;

--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -105,7 +105,7 @@ pub(crate) async fn generate_group_candidate(
     use openmls_traits::random::OpenMlsRand;
 
     let credential_with_key_and_signer = {
-        let credential = Credential::new(identity.to_vec(), CredentialType::Basic).unwrap();
+        let credential = Credential::new_basic(identity.to_vec());
 
         let signature_keypair = SignatureKeyPair::new(
             ciphersuite.signature_algorithm(),

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -148,7 +148,7 @@ impl MlsGroupTestSetup {
             let crypto = OpenMlsRustCrypto::default();
             let mut credentials = HashMap::new();
             for ciphersuite in crypto.crypto().supported_ciphersuites().iter() {
-                let credential = Credential::new(identity.clone(), CredentialType::Basic).unwrap();
+                let credential = Credential::new_basic(identity.clone());
                 let signature_keys = SignatureKeyPair::new(
                     ciphersuite.signature_algorithm(),
                     &mut *crypto.rand().borrow_rand().unwrap(),

--- a/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
+++ b/openmls/src/tree/tests_and_kats/kats/kat_encryption.rs
@@ -92,7 +92,7 @@ use thiserror::Error;
 
 use crate::{
     binary_tree::array_representation::LeafNodeIndex,
-    credentials::{Credential, CredentialType, CredentialWithKey},
+    credentials::{Credential, CredentialWithKey},
     framing::{
         mls_auth_content::AuthenticatedContent, mls_auth_content_in::AuthenticatedContentIn,
         mls_content_in::FramedContentBodyIn, *,
@@ -143,11 +143,10 @@ pub struct EncryptionTestVector {
 
 async fn generate_credential(
     identity: Vec<u8>,
-    credential_type: CredentialType,
     signature_algorithm: SignatureScheme,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
-    let credential = Credential::new(identity, credential_type).unwrap();
+    let credential = Credential::new_basic(identity);
     let signature_keys = SignatureKeyPair::new(
         signature_algorithm,
         &mut *backend.rand().borrow_rand().unwrap(),
@@ -171,13 +170,8 @@ async fn group(
 ) -> (CoreGroup, CredentialWithKey, SignatureKeyPair) {
     use crate::group::config::CryptoConfig;
 
-    let (credential_with_key, signer) = generate_credential(
-        "Kreator".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-        backend,
-    )
-    .await;
+    let (credential_with_key, signer) =
+        generate_credential("Kreator".into(), ciphersuite.signature_algorithm(), backend).await;
 
     let group = CoreGroup::builder(
         GroupId::random(backend),
@@ -201,7 +195,6 @@ async fn receiver_group(
 
     let (credential_with_key, signer) = generate_credential(
         "Receiver".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )

--- a/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
+++ b/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
@@ -4,7 +4,7 @@ use rstest::*;
 use rstest_reuse::apply;
 
 use crate::{
-    credentials::{test_utils::new_credential, CredentialType},
+    credentials::test_utils::new_credential,
     key_packages::KeyPackageBundle,
     treesync::{node::Node, RatchetTree, TreeSync},
 };
@@ -15,23 +15,11 @@ async fn test_free_leaf_computation(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
-    let (c_0, sk_0) = new_credential(
-        backend,
-        b"leaf0",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (c_0, sk_0) = new_credential(backend, b"leaf0", ciphersuite.signature_algorithm()).await;
 
     let kpb_0 = KeyPackageBundle::new(backend, &sk_0, ciphersuite, c_0).await;
 
-    let (c_3, sk_3) = new_credential(
-        backend,
-        b"leaf3",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (c_3, sk_3) = new_credential(backend, b"leaf3", ciphersuite.signature_algorithm()).await;
     let kpb_3 = KeyPackageBundle::new(backend, &sk_3, ciphersuite, c_3).await;
 
     // Build a rudimentary tree with two populated and two empty leaf nodes.
@@ -51,13 +39,8 @@ async fn test_free_leaf_computation(
 
     // Create and add a new leaf. It should go to leaf index 1
 
-    let (c_2, signer_2) = new_credential(
-        backend,
-        b"leaf2",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (c_2, signer_2) =
+        new_credential(backend, b"leaf2", ciphersuite.signature_algorithm()).await;
     let kpb_2 = KeyPackageBundle::new(backend, &signer_2, ciphersuite, c_2).await;
 
     let mut diff = tree.empty_diff();

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -21,12 +21,11 @@ fn create_backend_rust_crypto() {
 
 async fn generate_credential(
     identity: Vec<u8>,
-    credential_type: CredentialType,
     signature_algorithm: SignatureScheme,
     backend: &impl OpenMlsCryptoProvider,
 ) -> (CredentialWithKey, SignatureKeyPair) {
     // ANCHOR: create_basic_credential
-    let credential = Credential::new(identity, credential_type).unwrap();
+    let credential = Credential::new_basic(identity);
     // ANCHOR_END: create_basic_credential
     // ANCHOR: create_credential_keys
     let signature_keys = SignatureKeyPair::new(
@@ -85,37 +84,17 @@ async fn generate_key_package(
 #[apply(ciphersuites_and_backends)]
 async fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // Generate credentials with keys
-    let (alice_credential, alice_signature_keys) = generate_credential(
-        "Alice".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-        backend,
-    )
-    .await;
+    let (alice_credential, alice_signature_keys) =
+        generate_credential("Alice".into(), ciphersuite.signature_algorithm(), backend).await;
 
-    let (bob_credential, bob_signature_keys) = generate_credential(
-        "Bob".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-        backend,
-    )
-    .await;
+    let (bob_credential, bob_signature_keys) =
+        generate_credential("Bob".into(), ciphersuite.signature_algorithm(), backend).await;
 
-    let (charlie_credential, charlie_signature_keys) = generate_credential(
-        "Charlie".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-        backend,
-    )
-    .await;
+    let (charlie_credential, charlie_signature_keys) =
+        generate_credential("Charlie".into(), ciphersuite.signature_algorithm(), backend).await;
 
-    let (dave_credential, dave_signature_keys) = generate_credential(
-        "Dave".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-        backend,
-    )
-    .await;
+    let (dave_credential, dave_signature_keys) =
+        generate_credential("Dave".into(), ciphersuite.signature_algorithm(), backend).await;
 
     // Generate KeyPackages
     let bob_key_package = generate_key_package(
@@ -131,7 +110,6 @@ async fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoP
     // delivery service credentials
     let (ds_credential_with_key, ds_signature_keys) = generate_credential(
         "delivery-service".into(),
-        CredentialType::Basic,
         ciphersuite.signature_algorithm(),
         backend,
     )
@@ -1337,13 +1315,8 @@ async fn test_empty_input_errors(ciphersuite: Ciphersuite, backend: &impl OpenMl
     let group_id = GroupId::from_slice(b"Test Group");
 
     // Generate credentials with keys
-    let (alice_credential, alice_signature_keys) = generate_credential(
-        "Alice".into(),
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-        backend,
-    )
-    .await;
+    let (alice_credential, alice_signature_keys) =
+        generate_credential("Alice".into(), ciphersuite.signature_algorithm(), backend).await;
 
     // Define the MlsGroup configuration
     let mls_group_config = MlsGroupConfig::test_default(ciphersuite);

--- a/openmls/tests/key_store.rs
+++ b/openmls/tests/key_store.rs
@@ -6,7 +6,7 @@ use openmls_basic_credential::SignatureKeyPair;
 async fn test_store_key_package(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
     // ANCHOR: key_store_store
     // First we generate a credential and key package for our user.
-    let credential = Credential::new(b"User ID".to_vec(), CredentialType::Basic).unwrap();
+    let credential = Credential::new_basic(b"User ID".to_vec());
     let signature_keys = SignatureKeyPair::new(
         ciphersuite.into(),
         &mut *backend.rand().borrow_rand().unwrap(),

--- a/openmls/tests/test_external_commit.rs
+++ b/openmls/tests/test_external_commit.rs
@@ -14,13 +14,8 @@ async fn create_alice_group(
         .crypto_config(CryptoConfig::with_default_version(ciphersuite))
         .build();
 
-    let (credential_with_key, signature_keys) = new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (credential_with_key, signature_keys) =
+        new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
 
     let group = MlsGroup::new(
         backend,
@@ -78,13 +73,8 @@ async fn test_external_commit(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
 
     // Now, Bob wants to join Alice' group by an external commit. (Positive case.)
     {
-        let (bob_credential, bob_signature_keys) = new_credential(
-            backend,
-            b"Bob",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (bob_credential, bob_signature_keys) =
+            new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
         let (_bob_group, _, _) = MlsGroup::join_by_external_commit(
             backend,
@@ -103,13 +93,8 @@ async fn test_external_commit(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
 
     // Now, Bob wants to join Alice' group by an external commit. (Negative case, broken signature.)
     {
-        let (bob_credential, bob_signature_keys) = new_credential(
-            backend,
-            b"Bob",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (bob_credential, bob_signature_keys) =
+            new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
         let got_error = MlsGroup::join_by_external_commit(
             backend,
@@ -147,13 +132,8 @@ async fn test_group_info(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoP
     alice_group.merge_pending_commit(backend).await.unwrap();
 
     // Bob wants to join
-    let (bob_credential, bob_signature_keys) = new_credential(
-        backend,
-        b"Bob",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (bob_credential, bob_signature_keys) =
+        new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
     let verifiable_group_info = {
         let serialized_group_info = group_info.unwrap().tls_serialize_detached().unwrap();
@@ -207,13 +187,8 @@ async fn test_group_info(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoP
 
     // check that the returned group info from the external join is valid
     // Bob wants to join with another client
-    let (bob_credential, bob_signature_keys) = new_credential(
-        backend,
-        b"Bob 2",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (bob_credential, bob_signature_keys) =
+        new_credential(backend, b"Bob 2", ciphersuite.signature_algorithm()).await;
     let verifiable_group_info = {
         let serialized_group_info = group_info.unwrap().tls_serialize_detached().unwrap();
 

--- a/openmls/tests/test_mls_group.rs
+++ b/openmls/tests/test_mls_group.rs
@@ -48,29 +48,14 @@ async fn mls_group_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
         let group_id = GroupId::from_slice(b"Test Group");
 
         // Generate credentials with keys
-        let (alice_credential, alice_signer) = new_credential(
-            backend,
-            b"Alice",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (alice_credential, alice_signer) =
+            new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
 
-        let (bob_credential, bob_signer) = new_credential(
-            backend,
-            b"Bob",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (bob_credential, bob_signer) =
+            new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
-        let (charlie_credential, charlie_signer) = new_credential(
-            backend,
-            b"Charlie",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (charlie_credential, charlie_signer) =
+            new_credential(backend, b"Charlie", ciphersuite.signature_algorithm()).await;
 
         // Generate KeyPackages
         let bob_key_package = generate_key_package(
@@ -994,13 +979,8 @@ async fn test_empty_input_errors(ciphersuite: Ciphersuite, backend: &impl OpenMl
     let group_id = GroupId::from_slice(b"Test Group");
 
     // Generate credentials with keys
-    let (alice_credential, alice_signer) = new_credential(
-        backend,
-        b"Alice",
-        CredentialType::Basic,
-        ciphersuite.signature_algorithm(),
-    )
-    .await;
+    let (alice_credential, alice_signer) =
+        new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
 
     // Define the MlsGroup configuration
     let mls_group_config = MlsGroupConfig::test_default(ciphersuite);
@@ -1046,21 +1026,11 @@ async fn mls_group_ratchet_tree_extension(
         // === Positive case: using the ratchet tree extension ===
 
         // Generate credentials
-        let (alice_credential, alice_signer) = new_credential(
-            backend,
-            b"Alice",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (alice_credential, alice_signer) =
+            new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
 
-        let (bob_credential, bob_signer) = new_credential(
-            backend,
-            b"Bob",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (bob_credential, bob_signer) =
+            new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
         // Generate KeyPackages
         let bob_key_package = generate_key_package(
@@ -1108,21 +1078,11 @@ async fn mls_group_ratchet_tree_extension(
         // === Negative case: not using the ratchet tree extension ===
 
         // Generate credentials with keys
-        let (alice_credential, alice_signer) = new_credential(
-            backend,
-            b"Alice",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (alice_credential, alice_signer) =
+            new_credential(backend, b"Alice", ciphersuite.signature_algorithm()).await;
 
-        let (bob_credential, bob_signer) = new_credential(
-            backend,
-            b"Bob",
-            CredentialType::Basic,
-            ciphersuite.signature_algorithm(),
-        )
-        .await;
+        let (bob_credential, bob_signer) =
+            new_credential(backend, b"Bob", ciphersuite.signature_algorithm()).await;
 
         // Generate KeyPackages
         let bob_key_package = generate_key_package(

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -21,3 +21,10 @@ serde = { version = "1.0", features = ["derive"] }
 rand_core = "0.6"
 tls_codec = { workspace = true }
 async-trait = { workspace = true }
+# for the default signer
+ed25519-dalek = { version = "2.0.0-rc.2", features = ["rand_core"] }
+p256 = "0.13"
+p384 = "0.13"
+zeroize = "1.6"
+signature = "2.1"
+secrecy = { version = "0.8", features = ["serde"] }

--- a/traits/src/key_store.rs
+++ b/traits/src/key_store.rs
@@ -4,6 +4,7 @@
 #[derive(PartialEq)]
 pub enum MlsEntityId {
     SignatureKeyPair,
+    CertificateKeyPair,
     HpkePrivateKey,
     KeyPackage,
     PskBundle,

--- a/traits/src/signatures.rs
+++ b/traits/src/signatures.rs
@@ -10,3 +10,62 @@ pub trait Signer {
     /// The [`SignatureScheme`] of this signer.
     fn signature_scheme(&self) -> SignatureScheme;
 }
+
+/// Implement a default signer using the signature crate and:
+/// * p256 crate for [SignatureScheme::ECDSA_SECP256R1_SHA256]
+/// * p384 crate for [SignatureScheme::ECDSA_SECP384R1_SHA384]
+/// * ed25519-dalek crate for [SignatureScheme::ED25519]
+pub trait DefaultSigner {
+    /// Provides the private key to sign the payload
+    fn private_key(&self) -> &[u8];
+    /// The [`SignatureScheme`] of this signer.
+    fn signature_scheme(&self) -> SignatureScheme;
+}
+
+impl<T: DefaultSigner> Signer for T {
+    fn sign(&self, payload: &[u8]) -> Result<Vec<u8>, Error> {
+        use signature::Signer;
+        match self.signature_scheme() {
+            SignatureScheme::ECDSA_SECP256R1_SHA256 => {
+                let k = p256::ecdsa::SigningKey::from_bytes(self.private_key().into())
+                    .map_err(|_| Error::SigningError)?;
+                let signature: p256::ecdsa::Signature =
+                    k.try_sign(payload).map_err(|_| Error::SigningError)?;
+                Ok(signature.to_der().to_bytes().into())
+            }
+            SignatureScheme::ECDSA_SECP384R1_SHA384 => {
+                let k = p384::ecdsa::SigningKey::from_bytes(self.private_key().into())
+                    .map_err(|_| Error::SigningError)?;
+                let signature: p384::ecdsa::Signature =
+                    k.try_sign(payload).map_err(|_| Error::SigningError)?;
+                Ok(signature.to_der().to_bytes().into())
+            }
+            SignatureScheme::ED25519 => {
+                let k = match self.private_key().len() {
+                    // Compat layer for legacy keypairs [seed, pk]
+                    ed25519_dalek::KEYPAIR_LENGTH => {
+                        let mut sk = zeroize::Zeroizing::new([0u8; ed25519_dalek::KEYPAIR_LENGTH]);
+                        sk.copy_from_slice(self.private_key());
+                        ed25519_dalek::SigningKey::from_keypair_bytes(&sk)
+                            .map_err(|_| Error::SigningError)?
+                    }
+                    ed25519_dalek::SECRET_KEY_LENGTH => {
+                        let mut sk =
+                            zeroize::Zeroizing::new([0u8; ed25519_dalek::SECRET_KEY_LENGTH]);
+                        sk.copy_from_slice(self.private_key());
+                        ed25519_dalek::SigningKey::from_bytes(&sk)
+                    }
+                    _ => return Err(Error::SigningError),
+                };
+
+                let signature = k.try_sign(payload).map_err(|_| Error::SigningError)?;
+                Ok(signature.to_bytes().into())
+            }
+            _ => Err(Error::SigningError),
+        }
+    }
+
+    fn signature_scheme(&self) -> SignatureScheme {
+        self.signature_scheme()
+    }
+}

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -151,6 +151,11 @@ pub enum CryptoError {
     ExporterError,
     UnsupportedCiphersuite,
     TlsSerializationError,
+    IncompleteCertificateChain,
+    CertificateDecodingError,
+    CertificateEncodingError,
+    IncompleteCertificate(&'static str),
+    InvalidCertificate,
 }
 
 impl std::fmt::Display for CryptoError {

--- a/x509_credential/Cargo.toml
+++ b/x509_credential/Cargo.toml
@@ -1,12 +1,9 @@
 [package]
-name = "openmls_basic_credential"
+name = "openmls_x509_credential"
 version = "0.1.0"
-authors = ["OpenMLS Authors"]
 edition = "2021"
 description = "A Basic Credential implementation for OpenMLS"
 license = "MIT"
-documentation = "https://docs.rs/openmls_basic_credential"
-repository = "https://github.com/openmls/openmls/tree/main/basic_credential"
 readme = "README.md"
 
 [dependencies]
@@ -16,12 +13,13 @@ async-trait = { workspace = true }
 serde = "1.0"
 
 # Rust Crypto
-ed25519-dalek = { version = "2.0.0-rc.2", features = ["rand_core"] }
-p256 = "0.13"
-p384 = "0.13"
 secrecy = { version = "0.8", features = ["serde"] }
-rand_core = "0.6"
+x509-cert = "0.2"
+oid-registry = "0.6"
+
+[dev-dependencies]
+rcgen = "0.10"
+serde_json = "1.0"
 
 [features]
-clonable = [] # Make the keys clonable
 test-utils = [] # Only use for tests!

--- a/x509_credential/Readme.md
+++ b/x509_credential/Readme.md
@@ -1,0 +1,4 @@
+# Signature Keys for the x509 Credential
+
+This crate implements a simple signature key pair for x509 credential and
+implements the `Signer` trait required by the OpenMLS APIs.

--- a/x509_credential/src/lib.rs
+++ b/x509_credential/src/lib.rs
@@ -1,0 +1,343 @@
+//! # X509 Credential
+//!
+//! An implementation of the x509 credential from the MLS spec.
+
+use secrecy::{ExposeSecret, SecretVec};
+use serde::{Deserialize, Serialize};
+use std::{convert::From, fmt::Debug};
+use x509_cert::{
+    der::{Decode, Encode},
+    Certificate, PkiPath,
+};
+
+use openmls_traits::{
+    crypto::OpenMlsCrypto,
+    key_store::{MlsEntity, MlsEntityId, OpenMlsKeyStore},
+    types::{CryptoError, SignatureScheme},
+};
+
+fn expose_sk<S: serde::Serializer>(data: &SecretVec<u8>, ser: S) -> Result<S::Ok, S::Error> {
+    use serde::ser::SerializeSeq as _;
+    let exposed = data.expose_secret();
+    let mut seq = ser.serialize_seq(Some(exposed.len()))?;
+    for b in exposed.iter() {
+        seq.serialize_element(b)?;
+    }
+    seq.end()
+}
+
+mod serde_certificate {
+    use serde::{
+        de::Error as _,
+        ser::{Error as _, SerializeSeq},
+        Deserialize, Deserializer, Serializer,
+    };
+    use x509_cert::{
+        der::{Decode, Encode},
+        PkiPath,
+    };
+
+    pub(super) fn serialize<S: Serializer>(cert: &PkiPath, ser: S) -> Result<S::Ok, S::Error> {
+        let mut cert_data = Vec::new();
+        cert.encode_to_vec(&mut cert_data)
+            .map_err(S::Error::custom)?;
+        let mut seq = ser.serialize_seq(Some(cert_data.len()))?;
+        cert_data
+            .iter()
+            .try_for_each(|b| seq.serialize_element(b))?;
+        seq.end()
+    }
+
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<PkiPath, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let cert_data = Vec::<u8>::deserialize(deserializer)?;
+        PkiPath::from_der(&cert_data).map_err(D::Error::custom)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use openmls_traits::types::SignatureScheme;
+        use rcgen::generate_simple_self_signed;
+        use x509_cert::{der::Decode, Certificate, PkiPath};
+
+        use crate::CertificateKeyPair;
+
+        #[test]
+        fn should_serialize_ceritifcate() {
+            let cert_generator = |quantity: usize| -> PkiPath {
+                (0..quantity)
+                    .map(|_| {
+                        let subject_alt_names =
+                            vec!["hello.world.example".to_string(), "localhost".to_string()];
+                        let cert = generate_simple_self_signed(subject_alt_names).unwrap();
+                        let cert_der = cert.serialize_der().unwrap();
+                        Certificate::from_der(&cert_der).unwrap()
+                    })
+                    .collect()
+            };
+            let certs = cert_generator(3);
+            let kp = CertificateKeyPair {
+                private: vec![].into(),
+                certificate_chain: certs,
+                signature_scheme: SignatureScheme::ED25519,
+            };
+            let serialized = serde_json::to_value(&kp).unwrap();
+            let deserialized = serde_json::from_value::<CertificateKeyPair>(serialized).unwrap();
+            assert_eq!(deserialized.certificate_chain, kp.certificate_chain);
+        }
+    }
+}
+
+/// A signature key pair for the x509 credential.
+///
+/// This can be used as keys to implement the MLS x509 credential. It simple
+/// stores the private key and certificate chain.
+#[derive(Serialize, Deserialize)]
+pub struct CertificateKeyPair {
+    #[serde(serialize_with = "expose_sk")]
+    private: SecretVec<u8>,
+    #[serde(with = "serde_certificate")]
+    certificate_chain: PkiPath,
+    signature_scheme: SignatureScheme,
+}
+
+impl secrecy::SerializableSecret for CertificateKeyPair {}
+
+impl tls_codec::Size for CertificateKeyPair {
+    fn tls_serialized_len(&self) -> usize {
+        let cert_len: usize = self
+            .certificate_chain
+            .encoded_len()
+            .unwrap()
+            .try_into()
+            .unwrap();
+        self.private.expose_secret().tls_serialized_len()
+            + cert_len
+            + self.signature_scheme.tls_serialized_len()
+    }
+}
+
+impl tls_codec::Deserialize for CertificateKeyPair {
+    fn tls_deserialize<R: std::io::Read>(bytes: &mut R) -> Result<Self, tls_codec::Error>
+    where
+        Self: Sized,
+    {
+        let private = Vec::<u8>::tls_deserialize(bytes)?.into();
+        let cert_data = Vec::<u8>::tls_deserialize(bytes)?;
+        let certificate = PkiPath::from_der(&cert_data).map_err(|e| {
+            tls_codec::Error::DecodingError(format!("Error decoding certificate: {e}"))
+        })?;
+
+        let signature_scheme = SignatureScheme::tls_deserialize(bytes)?;
+        Ok(Self {
+            private,
+            certificate_chain: certificate,
+            signature_scheme,
+        })
+    }
+}
+
+impl tls_codec::Serialize for CertificateKeyPair {
+    fn tls_serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<usize, tls_codec::Error> {
+        let mut written = self.private.expose_secret().tls_serialize(writer)?;
+        let mut cert_data = Vec::new();
+        self.certificate_chain
+            .encode_to_vec(&mut cert_data)
+            .map_err(|e| {
+                tls_codec::Error::EncodingError(format!("Error encoding certificate: {e}"))
+            })?;
+        written += cert_data.tls_serialize(writer)?;
+        written += self.signature_scheme.tls_serialize(writer)?;
+        Ok(written)
+    }
+}
+
+impl Debug for CertificateKeyPair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SignatureKeyPair")
+            .field("private", &"***".to_string())
+            .field("certificate", &self.certificate_chain)
+            .field("signature_scheme", &self.signature_scheme)
+            .finish()
+    }
+}
+
+impl openmls_traits::signatures::DefaultSigner for CertificateKeyPair {
+    fn private_key(&self) -> &[u8] {
+        self.private.expose_secret().as_slice()
+    }
+
+    fn signature_scheme(&self) -> SignatureScheme {
+        self.signature_scheme
+    }
+}
+
+impl MlsEntity for CertificateKeyPair {
+    const ID: MlsEntityId = MlsEntityId::CertificateKeyPair;
+}
+
+impl CertificateKeyPair {
+    /// Constructs the `CertificateKeyPair` from a private key and a der encoded certificate chain
+    pub fn new(private: SecretVec<u8>, cert_chain: Vec<Vec<u8>>) -> Result<Self, CryptoError> {
+        if cert_chain.len() < 2 {
+            return Err(CryptoError::IncompleteCertificateChain);
+        }
+        let pki_path = cert_chain.into_iter().try_fold(
+            PkiPath::new(),
+            |mut acc, cert_data| -> Result<PkiPath, CryptoError> {
+                acc.push(
+                    Certificate::from_der(&cert_data)
+                        .map_err(|_| CryptoError::CertificateDecodingError)?,
+                );
+                Ok(acc)
+            },
+        )?;
+
+        let signature_scheme = pki_path[0].signature_scheme()?;
+
+        pki_path
+            .iter()
+            .try_for_each(|certificate| certificate.is_valid())?;
+
+        Ok(Self {
+            private,
+            certificate_chain: pki_path,
+            signature_scheme,
+        })
+    }
+
+    /// Store this signature key pair in the key store.
+    pub async fn store<T>(&self, key_store: &T) -> Result<(), <T as OpenMlsKeyStore>::Error>
+    where
+        T: OpenMlsKeyStore,
+        <T as OpenMlsKeyStore>::Error: From<CryptoError>,
+    {
+        key_store.store(self.public()?, self).await
+    }
+
+    /// Read a signature key pair from the key store.
+    pub async fn read(key_store: &impl OpenMlsKeyStore, public_key: &[u8]) -> Option<Self> {
+        key_store.read(public_key).await
+    }
+
+    /// Get the public key as byte slice.
+    pub fn public(&self) -> Result<&[u8], CryptoError> {
+        self.certificate_chain
+            .get(0)
+            .ok_or(CryptoError::IncompleteCertificateChain)?
+            .public_key()
+    }
+
+    /// Get the public key as byte vector.
+    pub fn to_public_vec(&self) -> Result<Vec<u8>, CryptoError> {
+        self.public().map(|p| p.to_owned())
+    }
+
+    /// Get the [`SignatureScheme`] of this signature key.
+    pub fn signature_scheme(&self) -> SignatureScheme {
+        self.signature_scheme
+    }
+
+    #[cfg(feature = "test-utils")]
+    pub fn private(&self) -> &[u8] {
+        self.private.expose_secret()
+    }
+}
+
+pub trait X509Ext {
+    fn is_valid(&self) -> Result<(), CryptoError>;
+
+    fn is_time_valid(&self) -> Result<bool, CryptoError>;
+
+    fn public_key(&self) -> Result<&[u8], CryptoError>;
+
+    fn signature_scheme(&self) -> Result<SignatureScheme, CryptoError>;
+
+    fn is_signed_by(
+        &self,
+        backend: &impl OpenMlsCrypto,
+        issuer: &Certificate,
+    ) -> Result<(), CryptoError>;
+}
+
+impl X509Ext for Certificate {
+    fn is_valid(&self) -> Result<(), CryptoError> {
+        if !self.is_time_valid()? {
+            return Err(CryptoError::InvalidCertificate);
+        }
+        Ok(())
+    }
+
+    fn is_time_valid(&self) -> Result<bool, CryptoError> {
+        // 'not_before' < now < 'not_after'
+        let x509_cert::time::Validity {
+            not_before,
+            not_after,
+        } = self.tbs_certificate.validity;
+        let x509_cert::time::Validity {
+            not_before: now, ..
+        } = x509_cert::time::Validity::from_now(core::time::Duration::default())
+            .map_err(|_| CryptoError::CryptoLibraryError)?;
+
+        let now = now.to_unix_duration();
+        let is_nbf = now > not_before.to_unix_duration();
+        let is_naf = now < not_after.to_unix_duration();
+        Ok(is_nbf && is_naf)
+    }
+
+    fn public_key(&self) -> Result<&[u8], CryptoError> {
+        self.tbs_certificate
+            .subject_public_key_info
+            .subject_public_key
+            .as_bytes()
+            .ok_or(CryptoError::IncompleteCertificate("spki"))
+    }
+
+    fn signature_scheme(&self) -> Result<SignatureScheme, CryptoError> {
+        let alg = self.tbs_certificate.subject_public_key_info.algorithm.oid;
+        let alg = oid_registry::Oid::new(std::borrow::Cow::Borrowed(alg.as_bytes()));
+
+        let scheme = if alg == oid_registry::OID_SIG_ED25519 {
+            SignatureScheme::ED25519
+        } else if alg == oid_registry::OID_SIG_ED448 {
+            SignatureScheme::ED448
+        } else if alg == oid_registry::OID_SIG_ECDSA_WITH_SHA256 {
+            SignatureScheme::ECDSA_SECP256R1_SHA256
+        } else if alg == oid_registry::OID_SIG_ECDSA_WITH_SHA384 {
+            SignatureScheme::ECDSA_SECP384R1_SHA384
+        } else if alg == oid_registry::OID_SIG_ECDSA_WITH_SHA512 {
+            SignatureScheme::ECDSA_SECP521R1_SHA512
+        } else {
+            return Err(CryptoError::UnsupportedSignatureScheme);
+        };
+        Ok(scheme)
+    }
+
+    fn is_signed_by(
+        &self,
+        backend: &impl OpenMlsCrypto,
+        issuer: &Certificate,
+    ) -> Result<(), CryptoError> {
+        let issuer_pk = issuer.public_key()?;
+        let cert_signature = self
+            .signature
+            .as_bytes()
+            .ok_or(CryptoError::InvalidCertificate)?;
+
+        use x509_cert::der::Encode as _;
+        let mut raw_tbs: Vec<u8> = vec![];
+        self.tbs_certificate
+            .encode(&mut raw_tbs)
+            .map_err(|_| CryptoError::CertificateEncodingError)?;
+        backend
+            .verify_signature(
+                self.signature_scheme()?,
+                &raw_tbs,
+                issuer_pk,
+                cert_signature,
+            )
+            .map_err(|_| CryptoError::InvalidSignature)
+    }
+}


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Adds support to x509 credentials in OpenMls

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
