### PR TITLE
fix: switch to CredentialType in the PerDomainTrustActor extension

### DIFF
--- a/openmls/src/extensions/mod.rs
+++ b/openmls/src/extensions/mod.rs
@@ -47,9 +47,7 @@ pub use external_sender_extension::{
 };
 pub use ratchet_tree_extension::RatchetTreeExtension;
 pub use required_capabilities::RequiredCapabilitiesExtension;
-pub use trust_anchor_extension::{
-    AnchorCredentialType, PerDomainTrustAnchor, PerDomainTrustAnchorsExtension,
-};
+pub use trust_anchor_extension::{PerDomainTrustAnchor, PerDomainTrustAnchorsExtension};
 
 #[cfg(test)]
 mod test_extensions;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?
Changes the `CredentialType` field in the trust certificates extension
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
