### PR TITLE
fix: clean encryption keypairs [WPB-3055]

### DIFF
--- a/openmls/src/framing/mls_content.rs
+++ b/openmls/src/framing/mls_content.rs
@@ -137,7 +137,7 @@ impl<'a> AuthenticatedContentTbm<'a> {
 }
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct FramedContentTbs {
+pub struct FramedContentTbs {
     pub(super) version: ProtocolVersion,
     pub(super) wire_format: WireFormat,
     pub(super) content: FramedContent,

--- a/openmls/src/framing/mod.rs
+++ b/openmls/src/framing/mod.rs
@@ -57,7 +57,7 @@ pub(crate) mod message_in;
 pub(crate) mod message_out;
 pub mod mls_auth_content;
 pub mod mls_auth_content_in;
-pub(crate) mod mls_content;
+pub mod mls_content;
 pub(crate) mod mls_content_in;
 pub(crate) mod private_message;
 pub(crate) mod private_message_in;

--- a/openmls/src/group/core_group/kat_passive_client.rs
+++ b/openmls/src/group/core_group/kat_passive_client.rs
@@ -282,7 +282,6 @@ impl PassiveClient {
     }
 
     async fn process_message(&mut self, message: MlsMessageIn) {
-        println!("{:#?}", message);
         let processed_message = self
             .group
             .as_mut()

--- a/openmls/src/group/mls_group/errors.rs
+++ b/openmls/src/group/mls_group/errors.rs
@@ -76,6 +76,9 @@ pub enum MlsGroupStateError {
     /// Requested pending proposal hasn't been found in local pending proposals
     #[error("Requested pending proposal hasn't been found in local pending proposals.")]
     PendingProposalNotFound,
+    /// When trying to delete an Update proposal, it's associated encryption key was not found. This is an implementor's error
+    #[error("When trying to delete an Update proposal, it's associated encryption key was not found. This is an implementor's error")]
+    EncryptionKeyNotFound,
 }
 
 /// Error merging pending commit

--- a/openmls/src/group/mls_group/extension.rs
+++ b/openmls/src/group/mls_group/extension.rs
@@ -39,7 +39,7 @@ impl MlsGroup {
             gce_proposal.clone(),
             ProposalOrRefType::Proposal,
         )?;
-        let reference = proposal.proposal_reference();
+        let reference = proposal.proposal_reference().clone();
 
         self.proposal_store.add(proposal);
 

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -24,6 +24,7 @@ mod exporting;
 mod updates;
 
 use crate::prelude::ConfirmationTag;
+use crate::treesync::node::encryption_keys::EncryptionKeyPair;
 use config::*;
 use errors::*;
 use openmls_traits::types::CryptoError;
@@ -156,14 +157,14 @@ pub struct MlsGroup {
     mls_group_config: MlsGroupConfig,
     // the internal `CoreGroup` used for lower level operations. See `CoreGroup` for more
     // information.
-    group: CoreGroup,
+    pub(crate) group: CoreGroup,
     // A [ProposalStore] that stores incoming proposals from the DS within one epoch.
     // The store is emptied after every epoch change.
     pub(crate) proposal_store: ProposalStore,
     // Own [`LeafNode`]s that were created for update proposals and that
     // are needed in case an update proposal is committed by another group
     // member. The vector is emptied after every epoch change.
-    own_leaf_nodes: Vec<LeafNode>,
+    pub own_leaf_nodes: Vec<LeafNode>,
     // The AAD that is used for all outgoing handshake messages. The AAD can be set through
     // `set_aad()`.
     aad: Vec<u8>,
@@ -432,13 +433,31 @@ impl MlsGroup {
     }
 
     /// Removes a specific proposal from the store.
-    pub fn remove_pending_proposal(
+    pub async fn remove_pending_proposal(
         &mut self,
-        proposal_ref: ProposalRef,
+        keystore: &impl OpenMlsKeyStore,
+        proposal_ref: &ProposalRef,
     ) -> Result<(), MlsGroupStateError> {
-        self.proposal_store
-            .remove(proposal_ref)
-            .ok_or(MlsGroupStateError::PendingProposalNotFound)
+        let maybe_proposal = self
+            .proposal_store
+            .proposals()
+            .find(|p| p.proposal_reference() == proposal_ref);
+
+        if let Some(proposal) = maybe_proposal {
+            if let Proposal::Update(UpdateProposal { leaf_node }) = proposal.proposal() {
+                let key = leaf_node.encryption_key().as_slice();
+                keystore
+                    .delete::<EncryptionKeyPair>(key)
+                    .await
+                    .map_err(|_| MlsGroupStateError::EncryptionKeyNotFound)?
+            }
+
+            self.proposal_store
+                .remove(proposal_ref)
+                .ok_or(MlsGroupStateError::PendingProposalNotFound)
+        } else {
+            Err(MlsGroupStateError::PendingProposalNotFound)
+        }
     }
 
     pub fn print_ratchet_tree(&self, message: &str) {

--- a/openmls/src/group/mls_group/processing.rs
+++ b/openmls/src/group/mls_group/processing.rs
@@ -172,15 +172,7 @@ impl MlsGroup {
         match &self.group_state {
             MlsGroupState::PendingCommit(state) => {
                 match state.deref() {
-                    PendingCommitState::Member(_) => {
-                        let old_state =
-                            mem::replace(&mut self.group_state, MlsGroupState::Operational);
-                        if let MlsGroupState::PendingCommit(pending_commit_state) = old_state {
-                            self.merge_staged_commit(backend, (*pending_commit_state).into())
-                                .await?;
-                        }
-                    }
-                    PendingCommitState::External(_) => {
+                    PendingCommitState::Member(_) | PendingCommitState::External(_) => {
                         let old_state =
                             mem::replace(&mut self.group_state, MlsGroupState::Operational);
                         if let MlsGroupState::PendingCommit(pending_commit_state) = old_state {

--- a/openmls/src/group/mls_group/proposal.rs
+++ b/openmls/src/group/mls_group/proposal.rs
@@ -78,7 +78,7 @@ macro_rules! impl_propose_fun {
                 proposal.clone(),
                 $ref_or_value,
             )?;
-            let proposal_ref = queued_proposal.proposal_reference();
+            let proposal_ref = queued_proposal.proposal_reference().clone();
             log::trace!("Storing proposal in queue {:?}", queued_proposal);
             self.proposal_store.add(queued_proposal);
 
@@ -233,7 +233,7 @@ impl MlsGroup {
             backend,
             add_proposal.clone(),
         )?;
-        let proposal_ref = proposal.proposal_reference();
+        let proposal_ref = proposal.proposal_reference().clone();
         self.proposal_store.add(proposal);
 
         let mls_message = self.content_to_mls_message(add_proposal, backend)?;
@@ -266,7 +266,7 @@ impl MlsGroup {
             backend,
             remove_proposal.clone(),
         )?;
-        let proposal_ref = proposal.proposal_reference();
+        let proposal_ref = proposal.proposal_reference().clone();
         self.proposal_store.add(proposal);
 
         let mls_message = self.content_to_mls_message(remove_proposal, backend)?;

--- a/openmls/src/group/mls_group/reinit.rs
+++ b/openmls/src/group/mls_group/reinit.rs
@@ -36,7 +36,7 @@ impl MlsGroup {
             reinit_proposal.clone(),
             ProposalOrRefType::Proposal,
         )?;
-        let reference = proposal.proposal_reference();
+        let reference = proposal.proposal_reference().clone();
 
         self.proposal_store.add(proposal);
 

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -673,12 +673,16 @@ async fn remove_prosposal_by_ref(ciphersuite: Ciphersuite, backend: &impl OpenMl
     assert_eq!(alice_group.proposal_store.proposals().count(), 1);
     // clearing the proposal by reference
     alice_group
-        .remove_pending_proposal(reference.clone())
+        .remove_pending_proposal(backend.key_store(), &reference)
+        .await
         .unwrap();
     assert!(alice_group.proposal_store.is_empty());
 
     // the proposal should not be stored anymore
-    let err = alice_group.remove_pending_proposal(reference).unwrap_err();
+    let err = alice_group
+        .remove_pending_proposal(backend.key_store(), &reference)
+        .await
+        .unwrap_err();
     assert_eq!(err, MlsGroupStateError::PendingProposalNotFound);
 
     // the commit should have no proposal

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -1703,7 +1703,7 @@ async fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
     let mut update_leaf_node = bob_leaf_node;
     update_leaf_node
         .update_and_re_sign(
-            alice_encryption_key.clone(),
+            Some(alice_encryption_key.clone()),
             None,
             bob_group.group_id().clone(),
             LeafNodeIndex::new(1),
@@ -1791,11 +1791,9 @@ async fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
 
     // We have to store the keypair with the proper label s.t. Bob can actually
     // process the commit.
-    let leaf_keypair = alice_group
-        .group()
-        .read_epoch_keypairs(backend)
-        .await
-        .into_iter()
+    let alice_epoch_keypairs = alice_group.group().read_epoch_keypairs(backend).await;
+    let leaf_keypair = alice_epoch_keypairs
+        .iter()
         .find(|keypair| keypair.public_key() == &alice_encryption_key)
         .unwrap();
     leaf_keypair.write_to_key_store(backend).await.unwrap();

--- a/openmls/src/key_packages/mod.rs
+++ b/openmls/src/key_packages/mod.rs
@@ -302,7 +302,8 @@ impl KeyPackage {
             .key_store()
             .delete::<HpkePrivateKey>(self.hpke_init_key().as_slice())
             .await
-            .map_err(KeyPackageDeleteError::KeyStoreError)
+            .map_err(KeyPackageDeleteError::KeyStoreError)?;
+        Ok(())
     }
 
     /// Get a reference to the extensions of this key package.

--- a/openmls/src/prelude.rs
+++ b/openmls/src/prelude.rs
@@ -25,8 +25,12 @@ pub use crate::extensions::{errors::*, *};
 
 // Framing
 pub use crate::framing::{
-    message_in::*, message_out::MlsMessageOutBody, message_out::*,
-    mls_content_in::FramedContentBodyIn, sender::*, validation::*, *,
+    message_in::*,
+    message_out::{MlsMessageOutBody, *},
+    mls_content_in::FramedContentBodyIn,
+    sender::*,
+    validation::*,
+    *,
 };
 
 // Key packages

--- a/openmls/tests/book_code.rs
+++ b/openmls/tests/book_code.rs
@@ -841,7 +841,8 @@ async fn book_operations(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoP
         .propose_add_member(backend, &alice_signature_keys, &bob_key_package)
         .expect("Could not create proposal to add Bob");
     alice_group
-        .remove_pending_proposal(proposal_ref)
+        .remove_pending_proposal(backend.key_store(), &proposal_ref)
+        .await
         .expect("The proposal was not found");
     // ANCHOR_END: rollback_proposal_by_ref
 

--- a/traits/src/key_store.rs
+++ b/traits/src/key_store.rs
@@ -8,6 +8,7 @@ pub enum MlsEntityId {
     KeyPackage,
     PskBundle,
     EncryptionKeyPair,
+    EpochEncryptionKeyPair,
     GroupState,
 }
 
@@ -24,14 +25,6 @@ pub trait MlsEntity: serde::Serialize + serde::de::DeserializeOwned {
             None
         }
     }
-}
-
-/// Blanket impl for when you have to lookup a list of entities from the keystore
-impl<T> MlsEntity for Vec<T>
-where
-    T: MlsEntity + std::fmt::Debug,
-{
-    const ID: MlsEntityId = T::ID;
 }
 
 #[cfg_attr(target_family = "wasm", async_trait::async_trait(?Send))]


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

* Move epoch encryption keypairs to a dedicated struct
* fixed pieces of code here and there to reduce allocations and make it more idiomatic
* fixed an issue with not saturated substraction when removing epoch keypairs
* fixed `removed_pending_proposal` not clearing the associated update proposal encryption keypair
* fixed `explicit_self_update` (update commit) was rekeying the own leaf node but it was again rekeyed later when the path was computed leaving a dangling encryption keypair
* `propose_explicit_self_update` also does not anymore rekey and leaves that decision to the caller

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
