### PR TITLE
fix: validate of Lifetime in KeyPackages only for senders

### DIFF
--- a/openmls/src/framing/mls_auth_content_in.rs
+++ b/openmls/src/framing/mls_auth_content_in.rs
@@ -54,6 +54,7 @@ impl AuthenticatedContentIn {
         sender_context: Option<SenderContext>,
         protocol_version: ProtocolVersion,
         group: &PublicGroup,
+        sender: bool,
     ) -> Result<AuthenticatedContent, ValidationError> {
         Ok(AuthenticatedContent {
             wire_format: self.wire_format,
@@ -65,6 +66,7 @@ impl AuthenticatedContentIn {
                     sender_context,
                     protocol_version,
                     group,
+                    sender,
                 )
                 .await?,
             auth: self.auth,

--- a/openmls/src/framing/mls_content_in.rs
+++ b/openmls/src/framing/mls_content_in.rs
@@ -57,6 +57,7 @@ impl FramedContentIn {
         sender_context: Option<SenderContext>,
         protocol_version: ProtocolVersion,
         group: &PublicGroup,
+        sender: bool,
     ) -> Result<FramedContent, ValidationError> {
         Ok(FramedContent {
             group_id: self.group_id,
@@ -71,6 +72,7 @@ impl FramedContentIn {
                     sender_context,
                     protocol_version,
                     group,
+                    sender,
                 )
                 .await?,
         })
@@ -145,6 +147,7 @@ impl FramedContentBodyIn {
         sender_context: Option<SenderContext>,
         protocol_version: ProtocolVersion,
         group: &PublicGroup,
+        sender: bool,
     ) -> Result<FramedContentBody, ValidationError> {
         Ok(match self {
             FramedContentBodyIn::Application(bytes) => FramedContentBody::Application(bytes),
@@ -156,6 +159,7 @@ impl FramedContentBodyIn {
                         sender_context,
                         protocol_version,
                         group,
+                        sender,
                     )
                     .await?,
             ),
@@ -170,6 +174,7 @@ impl FramedContentBodyIn {
                             sender_context,
                             protocol_version,
                             group,
+                            sender,
                         )
                         .await?,
                 )

--- a/openmls/src/framing/validation.rs
+++ b/openmls/src/framing/validation.rs
@@ -322,6 +322,7 @@ impl UnverifiedMessage {
                 self.sender_context,
                 protocol_version,
                 group,
+                false,
             )
             .await?;
         Ok((content, self.credential))

--- a/openmls/src/group/core_group/new_from_external_init.rs
+++ b/openmls/src/group/core_group/new_from_external_init.rs
@@ -52,6 +52,7 @@ impl CoreGroup {
             verifiable_group_info,
             // Existing proposals are discarded when joining by external commit.
             ProposalStore::new(),
+            true,
         )
         .await?;
         let group_context = public_group.group_context();

--- a/openmls/src/group/core_group/new_from_welcome.rs
+++ b/openmls/src/group/core_group/new_from_welcome.rs
@@ -151,11 +151,12 @@ impl CoreGroup {
             ratchet_tree,
             verifiable_group_info,
             ProposalStore::new(),
+            false,
         )
         .await?;
 
         KeyPackageIn::from(key_package.clone())
-            .validate(backend, ProtocolVersion::Mls10, &public_group)
+            .validate(backend, ProtocolVersion::Mls10, &public_group, false)
             .await?;
 
         // Find our own leaf in the tree.

--- a/openmls/src/group/core_group/test_proposals.rs
+++ b/openmls/src/group/core_group/test_proposals.rs
@@ -50,7 +50,7 @@ async fn proposal_queue_functions(ciphersuite: Ciphersuite, backend: &impl OpenM
     let kpi = KeyPackageIn::from(alice_update_key_package.clone());
 
     assert!(kpi
-        .standalone_validate(backend, ProtocolVersion::Mls10)
+        .standalone_validate(backend, ProtocolVersion::Mls10, true)
         .await
         .is_ok());
 
@@ -197,7 +197,7 @@ async fn proposal_queue_order(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
     let kpi = KeyPackageIn::from(alice_update_key_package.clone());
 
     assert!(kpi
-        .standalone_validate(backend, ProtocolVersion::Mls10)
+        .standalone_validate(backend, ProtocolVersion::Mls10, true)
         .await
         .is_ok());
 

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -48,7 +48,12 @@ impl MlsGroup {
         let mut inline_proposals = Vec::with_capacity(key_packages.len());
         for key_package in key_packages.into_iter() {
             let key_package = key_package
-                .validate(backend, ProtocolVersion::Mls10, self.group().public_group())
+                .validate(
+                    backend,
+                    ProtocolVersion::Mls10,
+                    self.group().public_group(),
+                    true,
+                )
                 .await?;
             inline_proposals.push(Proposal::Add(AddProposal { key_package }));
         }

--- a/openmls/src/group/mls_group/proposal.rs
+++ b/openmls/src/group/mls_group/proposal.rs
@@ -106,7 +106,12 @@ impl MlsGroup {
         self.is_operational()?;
 
         let key_package = joiner_key_package
-            .validate(backend, ProtocolVersion::Mls10, self.group().public_group())
+            .validate(
+                backend,
+                ProtocolVersion::Mls10,
+                self.group().public_group(),
+                true,
+            )
             .await?;
         let proposal =
             self.group
@@ -247,7 +252,12 @@ impl MlsGroup {
         self.is_operational()?;
 
         let key_package = joiner_key_package
-            .validate(backend, ProtocolVersion::Mls10, self.group().public_group())
+            .validate(
+                backend,
+                ProtocolVersion::Mls10,
+                self.group().public_group(),
+                true,
+            )
             .await?;
         let add_proposal =
             self.group

--- a/openmls/src/group/mls_group/updates.rs
+++ b/openmls/src/group/mls_group/updates.rs
@@ -189,7 +189,7 @@ impl MlsGroup {
             .into());
         };
         let own_leaf = own_leaf
-            .validate(self.group().public_group(), backend)
+            .validate(self.group().public_group(), backend, true)
             .await?;
 
         let update_proposal = self.group.create_update_proposal(
@@ -272,7 +272,7 @@ impl MlsGroup {
             .into());
         };
         let own_leaf = own_leaf
-            .validate(self.group().public_group(), backend)
+            .validate(self.group().public_group(), backend, true)
             .await?;
 
         let update_proposal = self.group.create_update_proposal(

--- a/openmls/src/group/public_group/mod.rs
+++ b/openmls/src/group/public_group/mod.rs
@@ -107,6 +107,7 @@ impl PublicGroup {
         ratchet_tree: RatchetTreeIn,
         verifiable_group_info: VerifiableGroupInfo,
         proposal_store: ProposalStore,
+        sender: bool,
     ) -> Result<(Self, GroupInfo), CreationFromExternalError> {
         let ciphersuite = verifiable_group_info.ciphersuite();
 
@@ -123,7 +124,8 @@ impl PublicGroup {
         // verifying the group info, since we need to find the Credential to verify the
         // signature against.
         let treesync =
-            TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree, group_id, true).await?;
+            TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree, group_id, true, sender)
+                .await?;
 
         let group_info: GroupInfo = {
             let signer_signature_key = treesync

--- a/openmls/src/group/public_group/tests.rs
+++ b/openmls/src/group/public_group/tests.rs
@@ -60,6 +60,7 @@ async fn public_group(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProv
         ratchet_tree.into(),
         verifiable_group_info,
         ProposalStore::new(),
+        true,
     )
     .await
     .unwrap();

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -1084,7 +1084,7 @@ async fn test_valsem105(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
                 .await;
 
         let kpi: KeyPackageIn = charlie_key_package.clone().into();
-        kpi.standalone_validate(backend, ProtocolVersion::Mls10)
+        kpi.standalone_validate(backend, ProtocolVersion::Mls10, true)
             .await
             .unwrap();
 

--- a/openmls/src/key_packages/key_package_in.rs
+++ b/openmls/src/key_packages/key_package_in.rs
@@ -119,8 +119,10 @@ impl KeyPackageIn {
         backend: &impl OpenMlsCryptoProvider,
         protocol_version: ProtocolVersion,
         group: &PublicGroup,
+        sender: bool,
     ) -> Result<KeyPackage, KeyPackageVerifyError> {
-        self._validate(backend, protocol_version, Some(group)).await
+        self._validate(backend, protocol_version, Some(group), sender)
+            .await
     }
 
     /// Verify that this key package is valid disregarding the group it is supposed to be used with.
@@ -128,8 +130,10 @@ impl KeyPackageIn {
         self,
         backend: &impl OpenMlsCryptoProvider,
         protocol_version: ProtocolVersion,
+        sender: bool,
     ) -> Result<KeyPackage, KeyPackageVerifyError> {
-        self._validate(backend, protocol_version, None).await
+        self._validate(backend, protocol_version, None, sender)
+            .await
     }
 
     async fn _validate(
@@ -137,6 +141,7 @@ impl KeyPackageIn {
         backend: &impl OpenMlsCryptoProvider,
         protocol_version: ProtocolVersion,
         group: Option<&PublicGroup>,
+        sender: bool,
     ) -> Result<KeyPackage, KeyPackageVerifyError> {
         // We first need to verify the LeafNode inside the KeyPackage
 
@@ -154,10 +159,10 @@ impl KeyPackageIn {
         let leaf_node = match verifiable_leaf_node {
             VerifiableLeafNode::KeyPackage(leaf_node) => {
                 if let Some(group) = group {
-                    leaf_node.validate(group, backend).await?
+                    leaf_node.validate(group, backend, sender).await?
                 } else {
                     leaf_node
-                        .standalone_validate(backend, signature_scheme)
+                        .standalone_validate(backend, signature_scheme, sender)
                         .await?
                 }
             }

--- a/openmls/src/key_packages/test_key_packages.rs
+++ b/openmls/src/key_packages/test_key_packages.rs
@@ -47,7 +47,7 @@ async fn generate_key_package(ciphersuite: Ciphersuite, backend: &impl OpenMlsCr
 
     let kpi = KeyPackageIn::from(key_package);
     assert!(kpi
-        .standalone_validate(backend, ProtocolVersion::Mls10)
+        .standalone_validate(backend, ProtocolVersion::Mls10, true)
         .await
         .is_ok());
 }
@@ -101,7 +101,7 @@ async fn application_id_extension(ciphersuite: Ciphersuite, backend: &impl OpenM
 
     let kpi = KeyPackageIn::from(key_package.clone());
     assert!(kpi
-        .standalone_validate(backend, ProtocolVersion::Mls10)
+        .standalone_validate(backend, ProtocolVersion::Mls10, true)
         .await
         .is_ok());
 
@@ -138,7 +138,7 @@ async fn key_package_validation(ciphersuite: Ciphersuite, backend: &impl OpenMls
     let kpi = KeyPackageIn::tls_deserialize(&mut encoded.as_slice()).unwrap();
 
     let err = kpi
-        .standalone_validate(backend, ProtocolVersion::Mls10)
+        .standalone_validate(backend, ProtocolVersion::Mls10, true)
         .await
         .unwrap_err();
     // Expect an invalid protocol version error
@@ -158,7 +158,7 @@ async fn key_package_validation(ciphersuite: Ciphersuite, backend: &impl OpenMls
     let kpi = KeyPackageIn::tls_deserialize(&mut encoded.as_slice()).unwrap();
 
     let err = kpi
-        .standalone_validate(backend, ProtocolVersion::Mls10)
+        .standalone_validate(backend, ProtocolVersion::Mls10, true)
         .await
         .unwrap_err();
     // Expect an invalid init/encryption key error

--- a/openmls/src/messages/group_info.rs
+++ b/openmls/src/messages/group_info.rs
@@ -123,6 +123,7 @@ impl VerifiableGroupInfo {
     pub async fn take_ratchet_tree(
         mut self,
         backend: &impl OpenMlsCryptoProvider,
+        sender: bool,
     ) -> Result<RatchetTree, GroupInfoError> {
         let cs = self.ciphersuite();
 
@@ -144,7 +145,8 @@ impl VerifiableGroupInfo {
         // although it clones the ratchet tree here...
         let group_id = self.group_id();
         let treesync =
-            TreeSync::from_ratchet_tree(backend, cs, ratchet_tree.clone(), group_id, true).await?;
+            TreeSync::from_ratchet_tree(backend, cs, ratchet_tree.clone(), group_id, true, sender)
+                .await?;
 
         let signer_signature_key = treesync
             .leaf(self.signer())

--- a/openmls/src/messages/mod.rs
+++ b/openmls/src/messages/mod.rs
@@ -196,12 +196,13 @@ impl CommitIn {
         sender_context: SenderContext,
         protocol_version: ProtocolVersion,
         group: &PublicGroup,
+        sender: bool,
     ) -> Result<Commit, ValidationError> {
         let mut proposals = Vec::with_capacity(self.proposals.len());
         for proposal in self.proposals.into_iter() {
             proposals.push(
                 proposal
-                    .validate(backend, ciphersuite, protocol_version, group)
+                    .validate(backend, ciphersuite, protocol_version, group, sender)
                     .await?,
             );
         }
@@ -237,7 +238,10 @@ impl CommitIn {
                     TreePosition::new(group_id, new_leaf_index)
                 }
             };
-            Some(path.into_verified(backend, tree_position, group).await?)
+            Some(
+                path.into_verified(backend, tree_position, group, sender)
+                    .await?,
+            )
         } else {
             None
         };

--- a/openmls/src/treesync/mod.rs
+++ b/openmls/src/treesync/mod.rs
@@ -446,6 +446,7 @@ impl TreeSync {
         ratchet_tree: RatchetTree,
         group_id: &GroupId,
         validate_leaf_node: bool,
+        sender: bool,
     ) -> Result<Self, TreeSyncFromNodesError> {
         // TODO #800: Unmerged leaves should be checked
         let mut ts_nodes: Vec<TreeNode<TreeSyncLeafNode, TreeSyncParentNode>> =
@@ -463,7 +464,7 @@ impl TreeSync {
                         let tree_position = TreePosition::new(group_id.clone(), index);
                         let ln = LeafNodeIn::from(ln)
                             .try_into_verifiable_leaf_node(Some(tree_position))?;
-                        ln.validate(backend, ciphersuite.signature_algorithm(), None)
+                        ln.validate(backend, ciphersuite.signature_algorithm(), None, sender)
                             .await?
                     } else {
                         ln

--- a/openmls/src/treesync/node/leaf_node.rs
+++ b/openmls/src/treesync/node/leaf_node.rs
@@ -785,14 +785,27 @@ impl VerifiableLeafNode {
         backend: &impl OpenMlsCryptoProvider,
         sc: SignatureScheme,
         group: Option<&PublicGroup>,
+        sender: bool,
     ) -> Result<LeafNode, LeafNodeValidationError> {
         match (self, group) {
-            (VerifiableLeafNode::KeyPackage(ln), None) => ln.standalone_validate(backend, sc).await,
-            (VerifiableLeafNode::KeyPackage(ln), Some(group)) => ln.validate(group, backend).await,
-            (VerifiableLeafNode::Update(ln), None) => ln.standalone_validate(backend, sc).await,
-            (VerifiableLeafNode::Update(ln), Some(group)) => ln.validate(group, backend).await,
-            (VerifiableLeafNode::Commit(ln), None) => ln.standalone_validate(backend, sc).await,
-            (VerifiableLeafNode::Commit(ln), Some(group)) => ln.validate(group, backend).await,
+            (VerifiableLeafNode::KeyPackage(ln), None) => {
+                ln.standalone_validate(backend, sc, sender).await
+            }
+            (VerifiableLeafNode::KeyPackage(ln), Some(group)) => {
+                ln.validate(group, backend, sender).await
+            }
+            (VerifiableLeafNode::Update(ln), None) => {
+                ln.standalone_validate(backend, sc, sender).await
+            }
+            (VerifiableLeafNode::Update(ln), Some(group)) => {
+                ln.validate(group, backend, sender).await
+            }
+            (VerifiableLeafNode::Commit(ln), None) => {
+                ln.standalone_validate(backend, sc, sender).await
+            }
+            (VerifiableLeafNode::Commit(ln), Some(group)) => {
+                ln.validate(group, backend, sender).await
+            }
         }
     }
 }

--- a/openmls/src/treesync/tests_and_kats/kats/kat_tree_operations.rs
+++ b/openmls/src/treesync/tests_and_kats/kats/kat_tree_operations.rs
@@ -64,7 +64,7 @@ async fn run_test_vector(
     let ratchet_tree = RatchetTree::from(RatchetTreeIn::from_nodes(nodes));
 
     let tree_before =
-        TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree, &group_id, false)
+        TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree, &group_id, false, true)
             .await
             .map_err(|e| format!("Error while creating tree sync: {e:?}"))?;
 

--- a/openmls/src/treesync/tests_and_kats/kats/kat_tree_validation.rs
+++ b/openmls/src/treesync/tests_and_kats/kats/kat_tree_validation.rs
@@ -109,10 +109,16 @@ async fn run_test_vector(
         .into_verified(ciphersuite, backend.crypto(), group_id)
         .unwrap();
 
-    let treesync =
-        TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree.clone(), group_id, true)
-            .await
-            .map_err(|e| format!("Error while creating tree sync: {e:?}"))?;
+    let treesync = TreeSync::from_ratchet_tree(
+        backend,
+        ciphersuite,
+        ratchet_tree.clone(),
+        group_id,
+        true,
+        false,
+    )
+    .await
+    .map_err(|e| format!("Error while creating tree sync: {e:?}"))?;
 
     let diff = treesync.empty_diff();
 

--- a/openmls/src/treesync/tests_and_kats/kats/kat_treekem.rs
+++ b/openmls/src/treesync/tests_and_kats/kats/kat_treekem.rs
@@ -98,7 +98,7 @@ pub async fn run_test_vector(test: TreeKemTest, backend: &impl OpenMlsCryptoProv
             .into_verified(ciphersuite, backend.crypto(), group_id)
             .unwrap();
 
-        TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree, group_id, true)
+        TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree, group_id, true, true)
             .await
             .unwrap()
     };

--- a/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
+++ b/openmls/src/treesync/tests_and_kats/tests/test_diff.rs
@@ -38,9 +38,10 @@ async fn test_free_leaf_computation(
 
     // Get the encryption key pair from the leaf.
     let group_id = GroupId::random(backend);
-    let tree = TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree, &group_id, true)
-        .await
-        .expect("error generating tree");
+    let tree =
+        TreeSync::from_ratchet_tree(backend, ciphersuite, ratchet_tree, &group_id, true, true)
+            .await
+            .expect("error generating tree");
 
     // Create and add a new leaf. It should go to leaf index 1
 

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -383,13 +383,14 @@ impl UpdatePathIn {
         backend: &impl OpenMlsCryptoProvider,
         tree_position: TreePosition,
         group: &PublicGroup,
+        sender: bool,
     ) -> Result<UpdatePath, UpdatePathError> {
         let leaf_node_in = self.leaf_node().clone();
         let verifiable_leaf_node =
             leaf_node_in.try_into_verifiable_leaf_node(Some(tree_position))?;
         match verifiable_leaf_node {
             VerifiableLeafNode::Commit(commit_leaf_node) => {
-                let leaf_node = commit_leaf_node.validate(group, backend).await?;
+                let leaf_node = commit_leaf_node.validate(group, backend, sender).await?;
                 Ok(UpdatePath {
                     leaf_node,
                     nodes: self.nodes,


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
