### PR TITLE
chore: remove support for the Kyber-based KEM

### DIFF
--- a/openmls/src/group/public_group/diff/compute_path.rs
+++ b/openmls/src/group/public_group/diff/compute_path.rs
@@ -75,7 +75,6 @@ impl<'a> PublicGroupDiff<'a> {
                             Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
                             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
                             Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
-                            Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519,
                         ]),
                         Some(&[]),
                         Some(&[]),

--- a/openmls/src/test_utils/mod.rs
+++ b/openmls/src/test_utils/mod.rs
@@ -234,9 +234,6 @@ pub async fn backends(backend: &impl OpenMlsCryptoProvider) {}
     ),
     case::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519(
         Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-    ),
-    case::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519(
-        Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519
     )
 )]
 #[allow(non_snake_case)]
@@ -252,7 +249,6 @@ pub async fn ciphersuites(ciphersuite: Ciphersuite) {}
     case::rust_crypto_MLS_256_DHKEMP384_AES256GCM_SHA384_P384(Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384, &OpenMlsRustCrypto::default()),
     case::rust_crypto_MLS_256_DHKEMP521_AES256GCM_SHA512_P521(Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521, &OpenMlsRustCrypto::default()),
     case::rust_crypto_MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519(Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519, &OpenMlsRustCrypto::default()),
-    case::rust_crypto_MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519(Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519, &OpenMlsRustCrypto::default()),
   )
 ]
 #[allow(non_snake_case)]

--- a/openmls/src/treesync/node/leaf_node/capabilities.rs
+++ b/openmls/src/treesync/node/leaf_node/capabilities.rs
@@ -204,7 +204,6 @@ pub(super) fn default_ciphersuites() -> Vec<Ciphersuite> {
         Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
         Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
         Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
-        Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519,
     ]
 }
 

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -30,8 +30,4 @@ zeroize = { version = "1.7", features = ["derive"] }
 signature = "2.1"
 thiserror = "1.0"
 generic-array = "0.14"
-
-[dependencies.hpke]
-git = "https://github.com/wireapp/rust-hpke.git"
-branch = "wire/unstable-pq-xyber-p521"
-features = ["x25519", "p256", "p384", "p521", "xyber768d00"]
+hpke = { version = "0.12", features = ["x25519", "p256", "p384", "p521"] }

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -96,8 +96,7 @@ impl OpenMlsCrypto for RustCrypto {
             | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
             | Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384
-            | Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521
-            | Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519 => Ok(()),
+            | Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521 => Ok(()),
             _ => Err(CryptoError::UnsupportedCiphersuite),
         }
     }
@@ -109,7 +108,6 @@ impl OpenMlsCrypto for RustCrypto {
             Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256,
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384,
             Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521,
-            Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519,
         ]
     }
 
@@ -483,15 +481,6 @@ impl OpenMlsCrypto for RustCrypto {
                 hpke::kdf::HkdfSha512,
                 hpke::kem::DhP521HkdfSha512,
             >(pk_r, info, aad, ptxt, &mut *rng),
-            HpkeConfig(
-                HpkeKemType::X25519Kyber768Draft00,
-                HpkeKdfType::HkdfSha256,
-                HpkeAeadType::AesGcm128,
-            ) => hpke_core::hpke_seal::<
-                hpke::aead::AesGcm128,
-                hpke::kdf::HkdfSha256,
-                hpke::kem::X25519Kyber768Draft00,
-            >(pk_r, info, aad, ptxt, &mut *rng),
             _ => Err(CryptoError::UnsupportedKem),
         }
     }
@@ -580,21 +569,6 @@ impl OpenMlsCrypto for RustCrypto {
                 aad,
                 input.ciphertext.as_slice(),
             )?,
-            HpkeConfig(
-                HpkeKemType::X25519Kyber768Draft00,
-                HpkeKdfType::HkdfSha256,
-                HpkeAeadType::AesGcm128,
-            ) => hpke_core::hpke_open::<
-                hpke::aead::AesGcm128,
-                hpke::kdf::HkdfSha256,
-                hpke::kem::X25519Kyber768Draft00,
-            >(
-                sk_r,
-                input.kem_output.as_slice(),
-                info,
-                aad,
-                input.ciphertext.as_slice(),
-            )?,
             _ => return Err(CryptoError::UnsupportedKem),
         };
 
@@ -660,15 +634,6 @@ impl OpenMlsCrypto for RustCrypto {
                 hpke::kdf::HkdfSha512,
                 hpke::kem::DhP521HkdfSha512,
             >(pk_r, info, exporter_context, exporter_length, &mut *rng)?,
-            HpkeConfig(
-                HpkeKemType::X25519Kyber768Draft00,
-                HpkeKdfType::HkdfSha256,
-                HpkeAeadType::AesGcm128,
-            ) => hpke_core::hpke_export_tx::<
-                hpke::aead::AesGcm128,
-                hpke::kdf::HkdfSha256,
-                hpke::kem::X25519Kyber768Draft00,
-            >(pk_r, info, exporter_context, exporter_length, &mut *rng)?,
             _ => return Err(CryptoError::UnsupportedKem),
         };
 
@@ -732,15 +697,6 @@ impl OpenMlsCrypto for RustCrypto {
                 hpke::kdf::HkdfSha512,
                 hpke::kem::DhP521HkdfSha512,
             >(enc, sk_r, info, exporter_context, exporter_length)?,
-            HpkeConfig(
-                HpkeKemType::X25519Kyber768Draft00,
-                HpkeKdfType::HkdfSha256,
-                HpkeAeadType::AesGcm128,
-            ) => hpke_core::hpke_export_rx::<
-                hpke::aead::AesGcm128,
-                hpke::kdf::HkdfSha256,
-                hpke::kem::X25519Kyber768Draft00,
-            >(enc, sk_r, info, exporter_context, exporter_length)?,
             _ => return Err(CryptoError::UnsupportedKem),
         };
 
@@ -766,9 +722,6 @@ impl OpenMlsCrypto for RustCrypto {
             }
             HpkeKemType::DhKem25519 => {
                 hpke_core::hpke_derive_keypair::<hpke::kem::X25519HkdfSha256>(ikm)
-            }
-            HpkeKemType::X25519Kyber768Draft00 => {
-                hpke_core::hpke_derive_keypair::<hpke::kem::X25519Kyber768Draft00>(ikm)
             }
             _ => Err(CryptoError::UnsupportedKem),
         }

--- a/traits/src/types.rs
+++ b/traits/src/types.rs
@@ -194,9 +194,6 @@ pub enum HpkeKemType {
 
     /// DH KEM on x448
     DhKem448 = 0x0021,
-
-    /// Hybrid x25519Kyber768Draft00 KEM
-    X25519Kyber768Draft00 = 0x0030,
 }
 
 /// KDF Types for HPKE
@@ -371,9 +368,6 @@ pub enum Ciphersuite {
 
     /// DH KEM P384 | AES-GCM 256 | SHA2-384 | EcDSA P384
     MLS_256_DHKEMP384_AES256GCM_SHA384_P384 = 0x0007,
-
-    /// x25519Kyber768Draft00 Hybrid KEM | AES-GCM 128 | SHA2-256 | Ed25519
-    MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519 = 0xF031, // 0xF000 + 0x0001 + 0x0030
 }
 
 impl core::fmt::Display for Ciphersuite {
@@ -409,7 +403,6 @@ impl TryFrom<u16> for Ciphersuite {
             0x0005 => Ok(Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521),
             0x0006 => Ok(Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448),
             0x0007 => Ok(Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384),
-            0xF031 => Ok(Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519),
             _ => Err(Self::Error::DecodingError(format!(
                 "{v} is not a valid ciphersuite value"
             ))),
@@ -466,8 +459,7 @@ impl Ciphersuite {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
-            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            | Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519 => {
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
                 HashType::Sha2_256
             }
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => HashType::Sha2_384,
@@ -482,8 +474,7 @@ impl Ciphersuite {
     pub const fn signature_algorithm(&self) -> SignatureScheme {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            | Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519 => {
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
                 SignatureScheme::ED25519
             }
             Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => {
@@ -507,10 +498,7 @@ impl Ciphersuite {
     pub const fn aead_algorithm(&self) -> AeadType {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-            | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
-            | Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519 => {
-                AeadType::Aes128Gcm
-            }
+            | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => AeadType::Aes128Gcm,
             Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
             | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => {
                 AeadType::ChaCha20Poly1305
@@ -527,8 +515,7 @@ impl Ciphersuite {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
             | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
-            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-            | Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519 => {
+            | Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
                 HpkeKdfType::HkdfSha256
             }
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => HpkeKdfType::HkdfSha384,
@@ -553,9 +540,6 @@ impl Ciphersuite {
             | Ciphersuite::MLS_256_DHKEMX448_CHACHA20POLY1305_SHA512_Ed448 => HpkeKemType::DhKem448,
             Ciphersuite::MLS_256_DHKEMP384_AES256GCM_SHA384_P384 => HpkeKemType::DhKemP384,
             Ciphersuite::MLS_256_DHKEMP521_AES256GCM_SHA512_P521 => HpkeKemType::DhKemP521,
-            Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519 => {
-                HpkeKemType::X25519Kyber768Draft00
-            }
         }
     }
 
@@ -564,10 +548,7 @@ impl Ciphersuite {
     pub const fn hpke_aead_algorithm(&self) -> HpkeAeadType {
         match self {
             Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-            | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256
-            | Ciphersuite::MLS_128_X25519KYBER768DRAFT00_AES128GCM_SHA256_Ed25519 => {
-                HpkeAeadType::AesGcm128
-            }
+            | Ciphersuite::MLS_128_DHKEMP256_AES128GCM_SHA256_P256 => HpkeAeadType::AesGcm128,
             Ciphersuite::MLS_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519 => {
                 HpkeAeadType::ChaCha20Poly1305
             }


### PR DESCRIPTION
Kyber PQ KEM is still being worked on and has an active draft:          
https://datatracker.ietf.org/doc/html/draft-cfrg-schwabe-kyber-04.      
                                                                        
Additionally, the hybrid scheme that combines X25519 and Kyber is       
also in the drafting phase:                                             
https://www.ietf.org/archive/id/draft-tls-westerbaan-xyber768d00-02.html
                                                                        
Given this, it makes no sense for us to provide support for Kyber-based 
KEMs.                                                                   