### PR TITLE
chore: replace instant with web-time [WPB-14399]

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,8 +21,8 @@ jobs:
         run: cargo test --no-fail-fast -p openmls
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTDOCFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
 
       - name: Run grcov
         id: coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,23 +12,28 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
-
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly
+          components: rustc, rust-std, cargo, llvm-tools, llvm-tools-preview
+          run:
       - uses: Swatinem/rust-cache@v2
+      - name: Install grcov
+        run: cargo install grcov
       - name: Run profiling tests
-        run: cargo test --no-fail-fast -p openmls
+        run: |
+          mkdir -p target/debug/coverage
+          cargo test --no-fail-fast -p openmls
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTDOCFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          LLVM_PROFILE_FILE: 'target/debug/coverage/openmls-%p-%m.profraw'
+          RUSTFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTDOCFLAGS: '-Cinstrument-coverage -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
 
       - name: Run grcov
         id: coverage
-        uses: actions-rs/grcov@v0.1
+        run: grcov . -s . --binary-path ./target/debug/ -t lcov --branch --ignore-not-existing -o ./target/debug/coverage/
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:
-          files: ${{ steps.coverage.outputs.report }}
+          files: target/debug/coverage/lcov

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -22,7 +22,7 @@ openmls_basic_credential = { version = "0.2.0", path = "../basic_credential", fe
 openmls_x509_credential = { version = "0.2.0", path = "../x509_credential" }
 x509-cert = "0.2"
 subtle = "2.5"
-fluvio-wasm-timer = "0.2"
+web-time = "1.1.0"
 indexmap = "2.0"
 itertools = "0.12"
 

--- a/openmls/src/binary_tree/array_representation/diff.rs
+++ b/openmls/src/binary_tree/array_representation/diff.rs
@@ -101,7 +101,7 @@ impl<'a, L: Clone + Debug + Default, P: Clone + Debug + Default> From<&'a ABinar
     }
 }
 
-impl<'a, L: Clone + Debug + Default, P: Clone + Debug + Default> AbDiff<'a, L, P> {
+impl<L: Clone + Debug + Default, P: Clone + Debug + Default> AbDiff<'_, L, P> {
     // Functions handling interactions with leaves.
     ///////////////////////////////////////////////
 

--- a/openmls/src/framing/message_in.rs
+++ b/openmls/src/framing/message_in.rs
@@ -176,6 +176,7 @@ impl MlsMessageIn {
 /// Enum containing a message for use with `process_message` and an
 /// [`MlsGroup`]. Both [`PublicMessage`] and [`PrivateMessage`] implement
 /// [`Into<ProtocolMessage>`].
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum ProtocolMessage {
     /// A [`ProtocolMessage`] containing a [`PrivateMessage`].

--- a/openmls/src/framing/private_message.rs
+++ b/openmls/src/framing/private_message.rs
@@ -320,6 +320,7 @@ impl PrivateMessage {
 ///     opaque padding[length_of_padding];
 /// } PrivateMessageContent;
 /// ```
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct PrivateMessageContent {
     // The `content` field is serialized and deserialized manually without the

--- a/openmls/src/framing/public_message.rs
+++ b/openmls/src/framing/public_message.rs
@@ -189,7 +189,7 @@ pub(crate) struct ConfirmedTranscriptHashInput<'a> {
     pub(super) signature: &'a Signature,
 }
 
-impl<'a> ConfirmedTranscriptHashInput<'a> {
+impl ConfirmedTranscriptHashInput<'_> {
     pub(crate) fn calculate_confirmed_transcript_hash(
         self,
         crypto: &impl OpenMlsCrypto,
@@ -238,7 +238,7 @@ pub(crate) struct InterimTranscriptHashInput<'a> {
     pub(crate) confirmation_tag: &'a ConfirmationTag,
 }
 
-impl<'a> InterimTranscriptHashInput<'a> {
+impl InterimTranscriptHashInput<'_> {
     pub fn calculate_interim_transcript_hash(
         self,
         crypto: &impl OpenMlsCrypto,

--- a/openmls/src/group/core_group/create_commit_params.rs
+++ b/openmls/src/group/core_group/create_commit_params.rs
@@ -89,7 +89,7 @@ impl<'a> CreateCommitParamsBuilder<'a> {
     }
 }
 
-impl<'a> CreateCommitParams<'a> {
+impl CreateCommitParams<'_> {
     pub(crate) fn builder() -> TempBuilderCCPM0 {
         TempBuilderCCPM0 {}
     }

--- a/openmls/src/group/core_group/proposals.rs
+++ b/openmls/src/group/core_group/proposals.rs
@@ -603,7 +603,7 @@ pub struct QueuedAddProposal<'a> {
     sender: &'a Sender,
 }
 
-impl<'a> QueuedAddProposal<'a> {
+impl QueuedAddProposal<'_> {
     /// Returns a reference to the proposal
     pub fn add_proposal(&self) -> &AddProposal {
         self.add_proposal
@@ -622,7 +622,7 @@ pub struct QueuedRemoveProposal<'a> {
     sender: &'a Sender,
 }
 
-impl<'a> QueuedRemoveProposal<'a> {
+impl QueuedRemoveProposal<'_> {
     /// Returns a reference to the proposal
     pub fn remove_proposal(&self) -> &RemoveProposal {
         self.remove_proposal
@@ -641,7 +641,7 @@ pub struct QueuedUpdateProposal<'a> {
     sender: &'a Sender,
 }
 
-impl<'a> QueuedUpdateProposal<'a> {
+impl QueuedUpdateProposal<'_> {
     /// Returns a reference to the proposal
     pub fn update_proposal(&self) -> &UpdateProposal {
         self.update_proposal
@@ -660,7 +660,7 @@ pub struct QueuedPskProposal<'a> {
     sender: &'a Sender,
 }
 
-impl<'a> QueuedPskProposal<'a> {
+impl QueuedPskProposal<'_> {
     /// Returns a reference to the proposal
     pub fn psk_proposal(&self) -> &PreSharedKeyProposal {
         self.psk_proposal

--- a/openmls/src/group/core_group/staged_commit.rs
+++ b/openmls/src/group/core_group/staged_commit.rs
@@ -111,8 +111,8 @@ impl CoreGroup {
     ///  - ValSem242
     ///  - ValSem243
     ///  - ValSem244
-    /// Returns an error if the given commit was sent by the owner of this
-    /// group.
+    ///
+    /// Returns an error if the given commit was sent by the owner of this group.
     pub(crate) async fn stage_commit(
         &self,
         mls_content: &AuthenticatedContent,

--- a/openmls/src/group/mls_group/membership.rs
+++ b/openmls/src/group/mls_group/membership.rs
@@ -109,7 +109,6 @@ impl MlsGroup {
     /// The [Welcome] is [Some] when the queue of pending proposals contained
     /// add proposals
     /// The [GroupInfo] is [Some] if the group has the `use_ratchet_tree_extension` flag set.
-
     ///
     /// Returns an error if there is a pending commit.
     // FIXME: #1217

--- a/openmls/src/group/mls_group/mod.rs
+++ b/openmls/src/group/mls_group/mod.rs
@@ -77,46 +77,46 @@ impl From<PendingCommitState> for StagedCommit {
 /// states and their transitions are as follows:
 ///
 /// * [`MlsGroupState::Operational`]: This is the main state of the group, which
-/// allows access to all of its functionality, (except merging pending commits,
-/// see the [`MlsGroupState::PendingCommit`] for more information) and it's the
-/// state the group starts in (except when created via
-/// [`MlsGroup::join_by_external_commit()`], see the functions documentation for
-/// more information). From this `Operational`, the group state can either
-/// transition to [`MlsGroupState::Inactive`], when it processes a commit that
-/// removes this client from the group, or to [`MlsGroupState::PendingCommit`],
-/// when this client creates a commit.
+///   allows access to all of its functionality, (except merging pending commits,
+///   see the [`MlsGroupState::PendingCommit`] for more information) and it's the
+///   state the group starts in (except when created via
+///   [`MlsGroup::join_by_external_commit()`], see the functions documentation for
+///   more information). From this `Operational`, the group state can either
+///   transition to [`MlsGroupState::Inactive`], when it processes a commit that
+///   removes this client from the group, or to [`MlsGroupState::PendingCommit`],
+///   when this client creates a commit.
 ///
 /// * [`MlsGroupState::Inactive`]: A group can enter this state from any other
-/// state when it processes a commit that removes this client from the group.
-/// This is a terminal state that the group can not exit from. If the clients
-/// wants to re-join the group, it can either be added by a group member or it
-/// can join via external commit.
+///   state when it processes a commit that removes this client from the group.
+///   This is a terminal state that the group can not exit from. If the clients
+///   wants to re-join the group, it can either be added by a group member or it
+///   can join via external commit.
 ///
 /// * [`MlsGroupState::PendingCommit`]: This state is split into two possible
-/// sub-states, one for each Commit type:
-/// [`PendingCommitState::Member`] and [`PendingCommitState::Member`]:
+///   sub-states, one for each Commit type:
+///   [`PendingCommitState::Member`] and [`PendingCommitState::Member`]:
 ///
 ///   * If the client creates a commit for this group, the `PendingCommit` state
-///   is entered with [`PendingCommitState::Member`] and with the [`StagedCommit`] as
-///   additional state variable. In this state, it can perform the same
-///   operations as in the [`MlsGroupState::Operational`], except that it cannot
-///   create proposals or commits. However, it can merge or clear the stored
-///   [`StagedCommit`], where both actions result in a transition to the
-///   [`MlsGroupState::Operational`]. Additionally, if a commit from another
-///   group member is processed, the own pending commit is also cleared and
-///   either the `Inactive` state is entered (if this client was removed from
-///   the group as part of the processed commit), or the `Operational` state is
-///   entered.
+///     is entered with [`PendingCommitState::Member`] and with the [`StagedCommit`] as
+///     additional state variable. In this state, it can perform the same
+///     operations as in the [`MlsGroupState::Operational`], except that it cannot
+///     create proposals or commits. However, it can merge or clear the stored
+///     [`StagedCommit`], where both actions result in a transition to the
+///     [`MlsGroupState::Operational`]. Additionally, if a commit from another
+///     group member is processed, the own pending commit is also cleared and
+///     either the `Inactive` state is entered (if this client was removed from
+///     the group as part of the processed commit), or the `Operational` state is
+///     entered.
 ///
 ///   * A group can enter the [`PendingCommitState::External`] sub-state only as
-///   the initial state when the group is created via
-///   [`MlsGroup::join_by_external_commit()`]. In contrast to the
-///   [`PendingCommitState::Member`] `PendingCommit` state, the only possible
-///   functionality that can be used is the [`MlsGroup::merge_pending_commit()`]
-///   function, which merges the pending external commit and transitions the
-///   state to [`MlsGroupState::PendingCommit`]. For more information on the
-///   external commit process, see [`MlsGroup::join_by_external_commit()`] or
-///   Section 11.2.1 of the MLS specification.
+///     the initial state when the group is created via
+///     [`MlsGroup::join_by_external_commit()`]. In contrast to the
+///     [`PendingCommitState::Member`] `PendingCommit` state, the only possible
+///     functionality that can be used is the [`MlsGroup::merge_pending_commit()`]
+///     function, which merges the pending external commit and transitions the
+///     state to [`MlsGroupState::PendingCommit`]. For more information on the
+///     external commit process, see [`MlsGroup::join_by_external_commit()`] or
+///     Section 11.2.1 of the MLS specification.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum MlsGroupState {
     /// There is currently a pending Commit that hasn't been merged yet.

--- a/openmls/src/group/public_group/diff/compute_path.rs
+++ b/openmls/src/group/public_group/diff/compute_path.rs
@@ -37,7 +37,7 @@ pub(crate) struct PathComputationResult {
     pub(crate) new_keypairs: Vec<EncryptionKeyPair>,
 }
 
-impl<'a> PublicGroupDiff<'a> {
+impl PublicGroupDiff<'_> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn compute_path<KeyStore: OpenMlsKeyStore>(
         &mut self,

--- a/openmls/src/group/public_group/staged_commit.rs
+++ b/openmls/src/group/public_group/staged_commit.rs
@@ -177,6 +177,7 @@ impl PublicGroup {
     ///  - ValSem242
     ///  - ValSem243
     ///  - ValSem244
+    ///
     /// Returns an error if the given commit was sent by the owner of this
     /// group.
     /// TODO #1255: This will be used by the `process_message` function of the

--- a/openmls/src/group/public_group/validation.rs
+++ b/openmls/src/group/public_group/validation.rs
@@ -399,6 +399,7 @@ impl PublicGroup {
     /// Validate Update proposals. This function implements the following checks:
     ///  - ValSem111: Update Proposal: The sender of a full Commit must not include own update proposals
     ///  - ValSem112: Update Proposal: The sender of a standalone update proposal must be of type member
+    ///
     /// TODO: #133 This validation must be updated according to Sec. 13.2
     pub(crate) fn validate_update_proposals(
         &self,

--- a/openmls/src/key_packages/lifetime.rs
+++ b/openmls/src/key_packages/lifetime.rs
@@ -1,4 +1,4 @@
-use fluvio_wasm_timer::{SystemTime, UNIX_EPOCH};
+use web_time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};

--- a/openmls/src/lib.rs
+++ b/openmls/src/lib.rs
@@ -147,11 +147,7 @@
 #![cfg_attr(not(test), forbid(unsafe_code))]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
-#![cfg(any(
-    target_pointer_width = "32",
-    target_pointer_width = "64",
-    target_pointer_width = "128"
-))]
+#![cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 
 // === Testing ===
 

--- a/openmls/src/messages/external_proposals.rs
+++ b/openmls/src/messages/external_proposals.rs
@@ -68,7 +68,7 @@ impl ExternalProposal {
     /// * `epoch` - group's epoch
     /// * `signer` - of the sender to sign the message
     /// * `sender` - index of the sender of the proposal (in the [crate::extensions::ExternalSendersExtension] array
-    /// from the Group Context)
+    ///   from the Group Context)
     pub fn new_remove(
         removed: LeafNodeIndex,
         group_id: GroupId,

--- a/openmls/src/tree/sender_ratchet.rs
+++ b/openmls/src/tree/sender_ratchet.rs
@@ -21,13 +21,13 @@ pub(crate) type Generation = u32;
 /// **Parameters**
 ///
 ///  - out_of_order_tolerance:
-/// This parameter defines a window for which decryption secrets are kept.
-/// This is useful in case the DS cannot guarantee that all application messages have total order within an epoch.
-/// Use this carefully, since keeping decryption secrets affects forward secrecy within an epoch.
-/// The default value is 5.
+///    This parameter defines a window for which decryption secrets are kept.
+///    This is useful in case the DS cannot guarantee that all application messages have total order within an epoch.
+///    Use this carefully, since keeping decryption secrets affects forward secrecy within an epoch.
+///    The default value is 5.
 ///  - maximum_forward_distance:
-/// This parameter defines how many incoming messages can be skipped. This is useful if the DS
-/// drops application messages. The default value is 1000.
+///    This parameter defines how many incoming messages can be skipped. This is useful if the DS
+///    drops application messages. The default value is 1000.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SenderRatchetConfiguration {
     out_of_order_tolerance: Generation,

--- a/openmls/src/treesync/diff.rs
+++ b/openmls/src/treesync/diff.rs
@@ -92,7 +92,7 @@ impl<'a> From<&'a TreeSync> for TreeSyncDiff<'a> {
     }
 }
 
-impl<'a> TreeSyncDiff<'a> {
+impl TreeSyncDiff<'_> {
     /// Filtered direct path, skips the nodes whose copath resolution is empty.
     pub(crate) fn filtered_direct_path(&self, leaf_index: LeafNodeIndex) -> Vec<ParentNodeIndex> {
         // Full direct path

--- a/openmls/src/treesync/node.rs
+++ b/openmls/src/treesync/node.rs
@@ -26,6 +26,7 @@ pub(crate) mod validate;
 ///     };
 /// } Node;
 /// ```
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsSize, TlsSerialize)]
 #[repr(u8)]
 pub enum Node {
@@ -37,6 +38,7 @@ pub enum Node {
     ParentNode(ParentNode),
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, TlsSize, TlsDeserialize, TlsSerialize,
 )]

--- a/openmls/src/treesync/treekem.rs
+++ b/openmls/src/treesync/treekem.rs
@@ -35,7 +35,7 @@ use crate::{
     versions::ProtocolVersion,
 };
 
-impl<'a> TreeSyncDiff<'a> {
+impl TreeSyncDiff<'_> {
     /// Encrypt the given `path` to the nodes in the copath resolution of the
     /// owner of this [`TreeSyncDiff`]. The `group_context` is used in the
     /// encryption of the nodes, while the `exclusion_list` is used to filter

--- a/x509_credential/Cargo.toml
+++ b/x509_credential/Cargo.toml
@@ -12,7 +12,7 @@ tls_codec = { workspace = true }
 async-trait = { workspace = true }
 serde = "1.0"
 openmls_basic_credential = { version = "0.2.0", path = "../basic_credential" }
-fluvio-wasm-timer = "0.2"
+web-time = "1.1.0"
 base64 = "0.21"
 uuid = "1.4"
 percent-encoding = "2.3"

--- a/x509_credential/src/lib.rs
+++ b/x509_credential/src/lib.rs
@@ -122,9 +122,9 @@ impl X509Ext for Certificate {
             not_after,
         } = self.tbs_certificate.validity;
 
-        let now = fluvio_wasm_timer::SystemTime::now();
+        let now = web_time::SystemTime::now();
         let now = now
-            .duration_since(fluvio_wasm_timer::UNIX_EPOCH)
+            .duration_since(web_time::UNIX_EPOCH)
             .map_err(|_| CryptoError::TimeError)?;
 
         let is_nbf = now > not_before.to_unix_duration();


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

instant is no longer maintained the recommended alternative is web-time.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
