### PR TITLE
test: can process old messages with blank leaves

### DIFF
--- a/openmls/src/group/public_group/tests.rs
+++ b/openmls/src/group/public_group/tests.rs
@@ -315,3 +315,252 @@ fn extract_staged_commit(ppm: ProcessedMessage) -> StagedCommit {
         ProcessedMessageContent::StagedCommitMessage(staged_content) => *staged_content,
     }
 }
+
+#[apply(ciphersuites_and_backends)]
+async fn old_messages_with_blank_leaves(
+    ciphersuite: Ciphersuite,
+    backend: &impl OpenMlsCryptoProvider,
+) {
+    Box::pin(async {
+        let group_id = GroupId::from_slice(b"test");
+
+        let (alice_credential_with_key, _, alice_signer, _) =
+            setup_client("Alice", ciphersuite, backend).await;
+        let (_, bob_kpb, _, _) = setup_client("Bob", ciphersuite, backend).await;
+        let (_, charlie_kpb, charlie_signer, _) =
+            setup_client("Charlie", ciphersuite, backend).await;
+        let (_, david_kpb, david_signer, _) = setup_client("David", ciphersuite, backend).await;
+
+        let mls_group_config = MlsGroupConfigBuilder::new()
+            .crypto_config(CryptoConfig::with_default_version(ciphersuite))
+            .use_ratchet_tree_extension(true)
+            .max_past_epochs(1)
+            .build();
+
+        let mut alice_group = MlsGroup::new_with_group_id(
+            backend,
+            &alice_signer,
+            &mls_group_config,
+            group_id,
+            alice_credential_with_key,
+        )
+        .await
+        .expect("create new group");
+
+        // Alice adds Bob, Charlie, and David.
+        let (_commit, welcome, _group_info) = alice_group
+            .add_members(
+                backend,
+                &alice_signer,
+                vec![
+                    bob_kpb.key_package().clone().into(),
+                    charlie_kpb.key_package().clone().into(),
+                    david_kpb.key_package().clone().into(),
+                ],
+            )
+            .await
+            .expect("add members");
+
+        alice_group
+            .merge_pending_commit(backend)
+            .await
+            .expect("merge pending commit");
+
+        let ratchet_tree = alice_group.export_ratchet_tree();
+        let _bob_group = MlsGroup::new_from_welcome(
+            backend,
+            &mls_group_config,
+            welcome.clone().into_welcome().expect("welcome message"),
+            Some(ratchet_tree.clone().into()),
+        )
+        .await
+        .expect("create group from Welcome");
+        let mut charlie_group = MlsGroup::new_from_welcome(
+            backend,
+            &mls_group_config,
+            welcome.clone().into_welcome().expect("welcome message"),
+            Some(ratchet_tree.clone().into()),
+        )
+        .await
+        .expect("create group from Welcome");
+        let mut david_group = MlsGroup::new_from_welcome(
+            backend,
+            &mls_group_config,
+            welcome.into_welcome().expect("welcome message"),
+            Some(ratchet_tree.into()),
+        )
+        .await
+        .expect("create group from Welcome");
+
+        // Alice removes Bob, leaving a blank leaf in the tree.
+        let (remove_bob_commit, _, _) = alice_group
+            .remove_members(backend, &alice_signer, &[LeafNodeIndex::new(1)])
+            .await
+            .expect("remove member");
+
+        let charlie_processed_remove_bob_commit = charlie_group
+            .process_message(
+                backend,
+                remove_bob_commit
+                    .clone()
+                    .into_protocol_message()
+                    .expect("protocol message"),
+            )
+            .await
+            .expect("process remove commit");
+        charlie_group
+            .merge_staged_commit(
+                backend,
+                extract_staged_commit(charlie_processed_remove_bob_commit),
+            )
+            .await
+            .expect("merge remove commit.");
+
+        let david_processed_remove_bob_commit = david_group
+            .process_message(
+                backend,
+                remove_bob_commit
+                    .clone()
+                    .into_protocol_message()
+                    .expect("Unexpected message type"),
+            )
+            .await
+            .expect("Could not process remove commit");
+        david_group
+            .merge_staged_commit(
+                backend,
+                extract_staged_commit(david_processed_remove_bob_commit),
+            )
+            .await
+            .expect("Error merging remove commit.");
+
+        alice_group
+            .merge_pending_commit(backend)
+            .await
+            .expect("error merging pending commit");
+
+        // Charlie sends an application message in the epoch that still contains the blank leaf.
+        let message_charlie = charlie_group
+            .create_message(backend, &charlie_signer, b"delayed application message")
+            .expect("could not create application message");
+
+        // David also sends a message.
+        let message_david = david_group
+            .create_message(backend, &david_signer, b"delayed application message 2")
+            .expect("could not create application message");
+
+        let alice_epoch_after_remove = alice_group.epoch().as_u64();
+
+        // Alice advances to the next epoch so the messages become old and must use the past store.
+        let (update_commit, welcome_option, _group_info) = alice_group
+            .self_update(backend, &alice_signer)
+            .await
+            .expect("Could not create update commit");
+        assert!(welcome_option.is_none());
+
+        let charlie_processed_update_commit = charlie_group
+            .process_message(
+                backend,
+                update_commit
+                    .clone()
+                    .into_protocol_message()
+                    .expect("Unexpected message type"),
+            )
+            .await
+            .expect("Could not process update commit");
+        charlie_group
+            .merge_staged_commit(
+                backend,
+                extract_staged_commit(charlie_processed_update_commit),
+            )
+            .await
+            .expect("merge update commit.");
+
+        let david_processed_message = david_group
+            .process_message(
+                backend,
+                update_commit
+                    .into_protocol_message()
+                    .expect("protocol message"),
+            )
+            .await
+            .expect("process update commit");
+        david_group
+            .merge_staged_commit(backend, extract_staged_commit(david_processed_message))
+            .await
+            .expect("merge update commit");
+
+        alice_group
+            .merge_pending_commit(backend)
+            .await
+            .expect("error merging pending commit");
+
+        assert_eq!(alice_epoch_after_remove + 1, alice_group.epoch().as_u64());
+
+        assert_eq!(
+            alice_group.epoch().as_u64(),
+            message_charlie
+                .clone()
+                .into_protocol_message()
+                .unwrap()
+                .epoch()
+                .as_u64()
+                + 1
+        );
+
+        // DS releases Charlie's buffered message to Alice.
+        let processed_message = alice_group
+            .process_message(
+                backend,
+                message_charlie
+                    .into_protocol_message()
+                    .expect("Unexpected message type"),
+            )
+            .await
+            .expect("Alice processes Charlie's message after self update");
+        if let ProcessedMessageContent::ApplicationMessage(application_message) =
+            processed_message.into_content()
+        {
+            assert_eq!(
+                application_message.into_bytes(),
+                b"delayed application message"
+            );
+        } else {
+            panic!("this must be an ApplicationMessage.");
+        }
+
+        assert_eq!(
+            alice_group.epoch().as_u64(),
+            message_david
+                .clone()
+                .into_protocol_message()
+                .unwrap()
+                .epoch()
+                .as_u64()
+                + 1
+        );
+
+        // The delivery service sends David's buffered message to Alice.
+        let processed_message = alice_group
+            .process_message(
+                backend,
+                message_david
+                    .into_protocol_message()
+                    .expect("protocol message"),
+            )
+            .await
+            .expect("Alice processes David's message after self update");
+
+        if let ProcessedMessageContent::ApplicationMessage(application_message) =
+            processed_message.into_content()
+        {
+            assert_eq!(
+                application_message.into_bytes(),
+                b"delayed application message 2"
+            );
+        } else {
+            panic!("this must be an ApplicationMessage.");
+        }
+    })
+    .await
+}


### PR DESCRIPTION
This proves that we don't suffer from the bug fixed in openmls/openmls@26eaa4d0e