### PR TITLE
chore: update various RustCrypto crates

### DIFF
--- a/basic_credential/Cargo.toml
+++ b/basic_credential/Cargo.toml
@@ -17,6 +17,7 @@ serde = "1.0"
 
 # Rust Crypto
 ed25519-dalek = { version = "3.0", features = ["rand_core"] }
+elliptic-curve = "0.14"
 p256 = "0.14"
 p384 = "0.14"
 p521 = "0.14"

--- a/basic_credential/Cargo.toml
+++ b/basic_credential/Cargo.toml
@@ -16,16 +16,16 @@ async-trait = { workspace = true }
 serde = "1.0"
 
 # Rust Crypto
-ed25519-dalek = { version = "2.0.0-rc.3", features = ["rand_core"] }
-p256 = "0.13"
-p384 = "0.13"
-p521 = "0.13"
+ed25519-dalek = { version = "3.0", features = ["rand_core"] }
+p256 = "0.14"
+p384 = "0.14"
+p521 = "0.14"
 secrecy = { version = "0.8", features = ["serde"] }
-rand_core = "0.6"
-getrandom = { version = "0.2", features = ["js"] }
+rand_core = "0.10"
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [dev-dependencies]
-rand = "0.8"
+rand = "0.10"
 
 [features]
 clonable = [] # Make the keys clonable

--- a/basic_credential/src/lib.rs
+++ b/basic_credential/src/lib.rs
@@ -264,7 +264,7 @@ pub mod tests {
             SignatureScheme::ECDSA_SECP521R1_SHA512,
         ];
         for scheme in schemes {
-            let kp = SignatureKeyPair::new(scheme, &mut rand::thread_rng()).unwrap();
+            let kp = SignatureKeyPair::new(scheme, &mut rand::rng()).unwrap();
             let sk = kp.private.expose_secret().clone();
             let pk = kp.public.clone();
             SignatureKeyPair::try_from_raw(scheme, sk, pk).unwrap();

--- a/basic_credential/src/lib.rs
+++ b/basic_credential/src/lib.rs
@@ -113,18 +113,18 @@ impl SignatureKeyPair {
         let (private, public): (SecretVec<u8>, Vec<u8>) = match signature_scheme {
             SignatureScheme::ECDSA_SECP256R1_SHA256 => {
                 let sk = p256::ecdsa::SigningKey::random(csprng);
-                let pk = sk.verifying_key().to_encoded_point(false).to_bytes().into();
+                let pk = sk.verifying_key().to_sec1_point(false).to_bytes().into();
                 (sk.to_bytes().to_vec().into(), pk)
             }
             SignatureScheme::ECDSA_SECP384R1_SHA384 => {
                 let sk = p384::ecdsa::SigningKey::random(csprng);
-                let pk = sk.verifying_key().to_encoded_point(false).to_bytes().into();
+                let pk = sk.verifying_key().to_sec1_point(false).to_bytes().into();
                 (sk.to_bytes().to_vec().into(), pk)
             }
             SignatureScheme::ECDSA_SECP521R1_SHA512 => {
                 let sk = p521::ecdsa::SigningKey::random(csprng);
                 let pk = p521::ecdsa::VerifyingKey::from(&sk)
-                    .to_encoded_point(false)
+                    .to_sec1_point(false)
                     .to_bytes()
                     .into();
                 (sk.to_bytes().to_vec().into(), pk)
@@ -202,7 +202,7 @@ impl SignatureKeyPair {
                     .map_err(|_| CryptoError::InvalidKey)?;
                 let sk_pk = p521::ecdsa::VerifyingKey::from(&sk);
 
-                if sk_pk.to_encoded_point(false) != pk.to_encoded_point(false) {
+                if sk_pk.to_sec1_point(false) != pk.to_sec1_point(false) {
                     return Err(CryptoError::MismatchKeypair);
                 }
             }

--- a/basic_credential/src/lib.rs
+++ b/basic_credential/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! For now this credential uses only RustCrypto.
 
+use elliptic_curve::Generate as _;
 use secrecy::{ExposeSecret, SecretVec};
 use std::fmt::Debug;
 
@@ -112,17 +113,17 @@ impl SignatureKeyPair {
     ) -> Result<Self, CryptoError> {
         let (private, public): (SecretVec<u8>, Vec<u8>) = match signature_scheme {
             SignatureScheme::ECDSA_SECP256R1_SHA256 => {
-                let sk = p256::ecdsa::SigningKey::random(csprng);
+                let sk = p256::ecdsa::SigningKey::generate_from_rng(csprng);
                 let pk = sk.verifying_key().to_sec1_point(false).to_bytes().into();
                 (sk.to_bytes().to_vec().into(), pk)
             }
             SignatureScheme::ECDSA_SECP384R1_SHA384 => {
-                let sk = p384::ecdsa::SigningKey::random(csprng);
+                let sk = p384::ecdsa::SigningKey::generate_from_rng(csprng);
                 let pk = sk.verifying_key().to_sec1_point(false).to_bytes().into();
                 (sk.to_bytes().to_vec().into(), pk)
             }
             SignatureScheme::ECDSA_SECP521R1_SHA512 => {
-                let sk = p521::ecdsa::SigningKey::random(csprng);
+                let sk = p521::ecdsa::SigningKey::generate_from_rng(csprng);
                 let pk = p521::ecdsa::VerifyingKey::from(&sk)
                     .to_sec1_point(false)
                     .to_bytes()

--- a/basic_credential/src/lib.rs
+++ b/basic_credential/src/lib.rs
@@ -108,7 +108,7 @@ impl SignatureKeyPair {
     /// Generates a fresh signature keypair using the [`SignatureScheme`].
     pub fn new(
         signature_scheme: SignatureScheme,
-        csprng: &mut impl rand_core::CryptoRngCore,
+        csprng: &mut impl rand_core::CryptoRng,
     ) -> Result<Self, CryptoError> {
         let (private, public): (SecretVec<u8>, Vec<u8>) = match signature_scheme {
             SignatureScheme::ECDSA_SECP256R1_SHA256 => {

--- a/openmls/Cargo.toml
+++ b/openmls/Cargo.toml
@@ -27,7 +27,7 @@ indexmap = "2.0"
 itertools = "0.12"
 
 # Only required for tests.
-rand = { version = "0.8", optional = true, features = ["getrandom"] }
+rand = { version = "0.10", optional = true }
 getrandom = { version = "0.2", optional = true, features = ["js"] }
 serde_json = { version = "1.0", optional = true }
 # Crypto backends required for KAT and testing - "test-utils" feature

--- a/openmls/src/binary_tree/test_binary_tree.rs
+++ b/openmls/src/binary_tree/test_binary_tree.rs
@@ -32,17 +32,13 @@ fn test_tree_basics() {
 
     // Test tree creation: Too many nodes (only in cases where usize is 64 bit).
     #[cfg(target_pointer_width = "64")]
-    // We allow uninitialized vectors because we don't want to allocate so much memory
-    #[allow(clippy::uninit_vec)]
-    unsafe {
+    {
         let len = u32::MAX as usize + 2;
-        let mut nodes: Vec<TreeNode<u32, u32>> = Vec::new();
-
-        nodes.set_len(len);
+        let nodes: Vec<TreeNode<u32, u32>> = Vec::with_capacity(len);
 
         assert_eq!(
             MlsBinaryTree::new(nodes).expect_err("No error while creating too large tree."),
-            MlsBinaryTreeError::OutOfRange
+            MlsBinaryTreeError::InvalidNumberOfNodes
         )
     }
 

--- a/openmls/src/binary_tree/test_binary_tree.rs
+++ b/openmls/src/binary_tree/test_binary_tree.rs
@@ -30,17 +30,17 @@ fn test_tree_basics() {
     assert_eq!(tree1.tree_size(), TreeSize::new(3));
     assert_eq!(tree1.leaf_count(), 2);
 
-    // Test tree creation: Too many nodes (only in cases where usize is 64 bit).
-    #[cfg(target_pointer_width = "64")]
-    {
-        let len = u32::MAX as usize + 2;
-        let nodes: Vec<TreeNode<u32, u32>> = Vec::with_capacity(len);
+    // // Test tree creation: Too many nodes (only in cases where usize is 64 bit).
+    // #[cfg(target_pointer_width = "64")]
+    // {
+    //     let len = u32::MAX as usize + 2;
+    //     let nodes: Vec<TreeNode<u32, u32>> = Vec::with_capacity(len);
 
-        assert_eq!(
-            MlsBinaryTree::new(nodes).expect_err("No error while creating too large tree."),
-            MlsBinaryTreeError::InvalidNumberOfNodes
-        )
-    }
+    //     assert_eq!(
+    //         MlsBinaryTree::new(nodes).expect_err("No error while creating too large tree."),
+    //         MlsBinaryTreeError::InvalidNumberOfNodes
+    //     )
+    // }
 
     // Node access
     assert_eq!(&1, tree1.leaf_by_index(LeafNodeIndex::new(0)));

--- a/openmls/src/binary_tree/test_binary_tree.rs
+++ b/openmls/src/binary_tree/test_binary_tree.rs
@@ -155,24 +155,6 @@ fn test_diff_merging() {
 
 #[test]
 #[wasm_bindgen_test::wasm_bindgen_test]
-fn test_new_tree_error() {
-    // Let's test what happens when the tree is getting too large.
-    let mut nodes: Vec<TreeNode<u32, u32>> = Vec::new();
-
-    // We allow uninitialized vectors because we don't want to allocate so much memory
-    #[allow(clippy::uninit_vec)]
-    unsafe {
-        nodes.set_len(u32::MAX as usize);
-
-        assert_eq!(
-            MlsBinaryTree::new(nodes).expect_err("no error adding beyond TREE_MAX"),
-            MlsBinaryTreeError::OutOfRange
-        )
-    }
-}
-
-#[test]
-#[wasm_bindgen_test::wasm_bindgen_test]
 fn test_diff_iter() {
     let nodes = (0..101)
         .map(|i| {

--- a/openmls/src/extensions/external_sender_extension.rs
+++ b/openmls/src/extensions/external_sender_extension.rs
@@ -74,7 +74,7 @@ mod test {
 
     #[apply(ciphersuites)]
     async fn test_serialize_deserialize(ciphersuite: Ciphersuite) {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let tests = {
             let mut external_sender_extensions = Vec::new();
 

--- a/openmls/src/group/mls_group/test_mls_group.rs
+++ b/openmls/src/group/mls_group/test_mls_group.rs
@@ -375,190 +375,193 @@ async fn test_invalid_plaintext(ciphersuite: Ciphersuite, backend: &impl OpenMls
 #[apply(ciphersuites_and_backends)]
 #[wasm_bindgen_test::wasm_bindgen_test]
 async fn test_pending_commit_logic(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let group_id = GroupId::from_slice(b"Test Group");
+    Box::pin(async move {
+        let group_id = GroupId::from_slice(b"Test Group");
 
-    let (alice_credential_with_key, _alice_kpb, alice_signer, _alice_pk) =
-        setup_client("Alice", ciphersuite, backend).await;
-    let (_bob_credential, bob_kpb, bob_signer, _bob_pk) =
-        setup_client("Bob", ciphersuite, backend).await;
+        let (alice_credential_with_key, _alice_kpb, alice_signer, _alice_pk) =
+            setup_client("Alice", ciphersuite, backend).await;
+        let (_bob_credential, bob_kpb, bob_signer, _bob_pk) =
+            setup_client("Bob", ciphersuite, backend).await;
 
-    // Define the MlsGroup configuration
-    let mls_group_config = MlsGroupConfig::test_default(ciphersuite);
+        // Define the MlsGroup configuration
+        let mls_group_config = MlsGroupConfig::test_default(ciphersuite);
 
-    // === Alice creates a group ===
-    let mut alice_group = MlsGroup::new_with_group_id(
-        backend,
-        &alice_signer,
-        &mls_group_config,
-        group_id,
-        alice_credential_with_key,
-    )
-    .await
-    .expect("An unexpected error occurred.");
-
-    // There should be no pending commit after group creation.
-    assert!(alice_group.pending_commit().is_none());
-
-    let bob_key_package = bob_kpb.key_package();
-
-    // Let's add bob
-    let (proposal, _) = alice_group
-        .propose_add_member(backend, &alice_signer, bob_key_package.clone().into())
+        // === Alice creates a group ===
+        let mut alice_group = MlsGroup::new_with_group_id(
+            backend,
+            &alice_signer,
+            &mls_group_config,
+            group_id,
+            alice_credential_with_key,
+        )
         .await
-        .expect("error creating self-update proposal");
+        .expect("An unexpected error occurred.");
 
-    let alice_processed_message = alice_group
-        .process_message(backend, proposal.into_protocol_message().unwrap())
-        .await
-        .expect("Could not process messages.");
-    assert!(alice_group.pending_commit().is_none());
+        // There should be no pending commit after group creation.
+        assert!(alice_group.pending_commit().is_none());
 
-    if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
-        alice_processed_message.into_content()
-    {
-        alice_group.store_pending_proposal(*staged_proposal);
-    } else {
-        unreachable!("Expected a StagedCommit.");
-    }
+        let bob_key_package = bob_kpb.key_package();
 
-    // There should be no pending commit after issuing and processing a proposal.
-    assert!(alice_group.pending_commit().is_none());
-
-    println!("\nCreating commit with add proposal.");
-    let (_msg, _welcome_option, _group_info) = alice_group
-        .self_update(backend, &alice_signer)
-        .await
-        .expect("error creating self-update commit");
-    println!("Done creating commit.");
-
-    // There should be a pending commit after issueing a proposal.
-    assert!(alice_group.pending_commit().is_some());
-
-    // If there is a pending commit, other commit- or proposal-creating actions
-    // should fail.
-    let error = alice_group
-        .add_members(backend, &alice_signer, vec![bob_key_package.clone().into()])
-        .await
-        .expect_err("no error committing while a commit is pending");
-    assert!(matches!(
-        error,
-        AddMembersError::GroupStateError(MlsGroupStateError::PendingCommit)
-    ));
-    let error = alice_group
-        .propose_add_member(backend, &alice_signer, bob_key_package.clone().into())
-        .await
-        .expect_err("no error creating a proposal while a commit is pending");
-    assert!(matches!(
-        error,
-        ProposeAddMemberError::GroupStateError(MlsGroupStateError::PendingCommit)
-    ));
-    let error = alice_group
-        .remove_members(backend, &alice_signer, &[LeafNodeIndex::new(1)])
-        .await
-        .expect_err("no error committing while a commit is pending");
-    assert!(matches!(
-        error,
-        RemoveMembersError::GroupStateError(MlsGroupStateError::PendingCommit)
-    ));
-    let error = alice_group
-        .propose_remove_member(backend, &alice_signer, LeafNodeIndex::new(1))
-        .expect_err("no error creating a proposal while a commit is pending");
-    assert!(matches!(
-        error,
-        ProposeRemoveMemberError::GroupStateError(MlsGroupStateError::PendingCommit)
-    ));
-    let error = alice_group
-        .commit_to_pending_proposals(backend, &alice_signer)
-        .await
-        .expect_err("no error committing while a commit is pending");
-    assert!(matches!(
-        error,
-        CommitToPendingProposalsError::GroupStateError(MlsGroupStateError::PendingCommit)
-    ));
-    let error = alice_group
-        .self_update(backend, &alice_signer)
-        .await
-        .expect_err("no error committing while a commit is pending");
-    assert!(matches!(
-        error,
-        SelfUpdateError::GroupStateError(MlsGroupStateError::PendingCommit)
-    ));
-    let error = alice_group
-        .propose_self_update(backend, &alice_signer)
-        .await
-        .expect_err("no error creating a proposal while a commit is pending");
-    assert!(matches!(
-        error,
-        ProposeSelfUpdateError::GroupStateError(MlsGroupStateError::PendingCommit)
-    ));
-
-    // Clearing the pending commit should actually clear it.
-    alice_group.clear_pending_commit();
-    assert!(alice_group.pending_commit().is_none());
-
-    // Creating a new commit should commit the same proposals.
-    let (_msg, welcome_option, _group_info) = alice_group
-        .self_update(backend, &alice_signer)
-        .await
-        .expect("error creating self-update commit");
-
-    // Merging the pending commit should clear the pending commit and we should
-    // end up in the same state as bob.
-    alice_group
-        .merge_pending_commit(backend)
-        .await
-        .expect("error merging pending commit");
-    assert!(alice_group.pending_commit().is_none());
-
-    let mut bob_group = MlsGroup::new_from_welcome(
-        backend,
-        &mls_group_config,
-        welcome_option
-            .expect("no welcome after commit")
-            .into_welcome()
-            .expect("Unexpected message type."),
-        Some(alice_group.export_ratchet_tree().into()),
-    )
-    .await
-    .expect("error creating group from welcome");
-
-    assert_eq!(
-        bob_group.export_ratchet_tree(),
-        alice_group.export_ratchet_tree()
-    );
-    assert_eq!(
-        bob_group.export_secret(backend, "test", &[], ciphersuite.hash_length()),
-        alice_group.export_secret(backend, "test", &[], ciphersuite.hash_length())
-    );
-
-    // While a commit is pending, merging Bob's commit should clear the pending commit.
-    let (_msg, _welcome_option, _group_info) = alice_group
-        .self_update(backend, &alice_signer)
-        .await
-        .expect("error creating self-update commit");
-
-    let (msg, _welcome_option, _group_info) = bob_group
-        .self_update(backend, &bob_signer)
-        .await
-        .expect("error creating self-update commit");
-
-    let alice_processed_message = alice_group
-        .process_message(backend, msg.into_protocol_message().unwrap())
-        .await
-        .expect("Could not process messages.");
-    assert!(alice_group.pending_commit().is_some());
-
-    if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
-        alice_processed_message.into_content()
-    {
-        alice_group
-            .merge_staged_commit(backend, *staged_commit)
+        // Let's add bob
+        let (proposal, _) = alice_group
+            .propose_add_member(backend, &alice_signer, bob_key_package.clone().into())
             .await
-            .expect("Error merging commit.");
-    } else {
-        unreachable!("Expected a StagedCommit.");
-    }
-    assert!(alice_group.pending_commit().is_none());
+            .expect("error creating self-update proposal");
+
+        let alice_processed_message = alice_group
+            .process_message(backend, proposal.into_protocol_message().unwrap())
+            .await
+            .expect("Could not process messages.");
+        assert!(alice_group.pending_commit().is_none());
+
+        if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
+            alice_processed_message.into_content()
+        {
+            alice_group.store_pending_proposal(*staged_proposal);
+        } else {
+            unreachable!("Expected a StagedCommit.");
+        }
+
+        // There should be no pending commit after issuing and processing a proposal.
+        assert!(alice_group.pending_commit().is_none());
+
+        println!("\nCreating commit with add proposal.");
+        let (_msg, _welcome_option, _group_info) = alice_group
+            .self_update(backend, &alice_signer)
+            .await
+            .expect("error creating self-update commit");
+        println!("Done creating commit.");
+
+        // There should be a pending commit after issueing a proposal.
+        assert!(alice_group.pending_commit().is_some());
+
+        // If there is a pending commit, other commit- or proposal-creating actions
+        // should fail.
+        let error = alice_group
+            .add_members(backend, &alice_signer, vec![bob_key_package.clone().into()])
+            .await
+            .expect_err("no error committing while a commit is pending");
+        assert!(matches!(
+            error,
+            AddMembersError::GroupStateError(MlsGroupStateError::PendingCommit)
+        ));
+        let error = alice_group
+            .propose_add_member(backend, &alice_signer, bob_key_package.clone().into())
+            .await
+            .expect_err("no error creating a proposal while a commit is pending");
+        assert!(matches!(
+            error,
+            ProposeAddMemberError::GroupStateError(MlsGroupStateError::PendingCommit)
+        ));
+        let error = alice_group
+            .remove_members(backend, &alice_signer, &[LeafNodeIndex::new(1)])
+            .await
+            .expect_err("no error committing while a commit is pending");
+        assert!(matches!(
+            error,
+            RemoveMembersError::GroupStateError(MlsGroupStateError::PendingCommit)
+        ));
+        let error = alice_group
+            .propose_remove_member(backend, &alice_signer, LeafNodeIndex::new(1))
+            .expect_err("no error creating a proposal while a commit is pending");
+        assert!(matches!(
+            error,
+            ProposeRemoveMemberError::GroupStateError(MlsGroupStateError::PendingCommit)
+        ));
+        let error = alice_group
+            .commit_to_pending_proposals(backend, &alice_signer)
+            .await
+            .expect_err("no error committing while a commit is pending");
+        assert!(matches!(
+            error,
+            CommitToPendingProposalsError::GroupStateError(MlsGroupStateError::PendingCommit)
+        ));
+        let error = alice_group
+            .self_update(backend, &alice_signer)
+            .await
+            .expect_err("no error committing while a commit is pending");
+        assert!(matches!(
+            error,
+            SelfUpdateError::GroupStateError(MlsGroupStateError::PendingCommit)
+        ));
+        let error = alice_group
+            .propose_self_update(backend, &alice_signer)
+            .await
+            .expect_err("no error creating a proposal while a commit is pending");
+        assert!(matches!(
+            error,
+            ProposeSelfUpdateError::GroupStateError(MlsGroupStateError::PendingCommit)
+        ));
+
+        // Clearing the pending commit should actually clear it.
+        alice_group.clear_pending_commit();
+        assert!(alice_group.pending_commit().is_none());
+
+        // Creating a new commit should commit the same proposals.
+        let (_msg, welcome_option, _group_info) = alice_group
+            .self_update(backend, &alice_signer)
+            .await
+            .expect("error creating self-update commit");
+
+        // Merging the pending commit should clear the pending commit and we should
+        // end up in the same state as bob.
+        alice_group
+            .merge_pending_commit(backend)
+            .await
+            .expect("error merging pending commit");
+        assert!(alice_group.pending_commit().is_none());
+
+        let mut bob_group = MlsGroup::new_from_welcome(
+            backend,
+            &mls_group_config,
+            welcome_option
+                .expect("no welcome after commit")
+                .into_welcome()
+                .expect("Unexpected message type."),
+            Some(alice_group.export_ratchet_tree().into()),
+        )
+        .await
+        .expect("error creating group from welcome");
+
+        assert_eq!(
+            bob_group.export_ratchet_tree(),
+            alice_group.export_ratchet_tree()
+        );
+        assert_eq!(
+            bob_group.export_secret(backend, "test", &[], ciphersuite.hash_length()),
+            alice_group.export_secret(backend, "test", &[], ciphersuite.hash_length())
+        );
+
+        // While a commit is pending, merging Bob's commit should clear the pending commit.
+        let (_msg, _welcome_option, _group_info) = alice_group
+            .self_update(backend, &alice_signer)
+            .await
+            .expect("error creating self-update commit");
+
+        let (msg, _welcome_option, _group_info) = bob_group
+            .self_update(backend, &bob_signer)
+            .await
+            .expect("error creating self-update commit");
+
+        let alice_processed_message = alice_group
+            .process_message(backend, msg.into_protocol_message().unwrap())
+            .await
+            .expect("Could not process messages.");
+        assert!(alice_group.pending_commit().is_some());
+
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            alice_processed_message.into_content()
+        {
+            alice_group
+                .merge_staged_commit(backend, *staged_commit)
+                .await
+                .expect("Error merging commit.");
+        } else {
+            unreachable!("Expected a StagedCommit.");
+        }
+        assert!(alice_group.pending_commit().is_none());
+    })
+    .await
 }
 
 // Test that the key package and the corresponding private key are deleted when

--- a/openmls/src/group/public_group/tests.rs
+++ b/openmls/src/group/public_group/tests.rs
@@ -21,280 +21,283 @@ use crate::test_utils::*;
 
 #[apply(ciphersuites_and_backends)]
 async fn public_group(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    let group_id = GroupId::from_slice(b"Test Group");
+    Box::pin(async move {
+        let group_id = GroupId::from_slice(b"Test Group");
 
-    let (alice_credential_with_key, _alice_kpb, alice_signer, _alice_pk) =
-        setup_client("Alice", ciphersuite, backend).await;
-    let (_bob_credential, bob_kpb, bob_signer, _bob_pk) =
-        setup_client("Bob", ciphersuite, backend).await;
-    let (_charlie_credential, charlie_kpb, charlie_signer, _charlie_pk) =
-        setup_client("Charly", ciphersuite, backend).await;
+        let (alice_credential_with_key, _alice_kpb, alice_signer, _alice_pk) =
+            setup_client("Alice", ciphersuite, backend).await;
+        let (_bob_credential, bob_kpb, bob_signer, _bob_pk) =
+            setup_client("Bob", ciphersuite, backend).await;
+        let (_charlie_credential, charlie_kpb, charlie_signer, _charlie_pk) =
+            setup_client("Charly", ciphersuite, backend).await;
 
-    // Define the MlsGroup configuration
-    // Set plaintext wire format policy s.t. the public group can track changes.
-    let mls_group_config = MlsGroupConfigBuilder::new()
-        .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
-        .crypto_config(CryptoConfig::with_default_version(ciphersuite))
-        .build();
+        // Define the MlsGroup configuration
+        // Set plaintext wire format policy s.t. the public group can track changes.
+        let mls_group_config = MlsGroupConfigBuilder::new()
+            .wire_format_policy(PURE_PLAINTEXT_WIRE_FORMAT_POLICY)
+            .crypto_config(CryptoConfig::with_default_version(ciphersuite))
+            .build();
 
-    // === Alice creates a group ===
-    let mut alice_group = MlsGroup::new_with_group_id(
-        backend,
-        &alice_signer,
-        &mls_group_config,
-        group_id,
-        alice_credential_with_key,
-    )
-    .await
-    .expect("An unexpected error occurred.");
-
-    // === Create a public group that tracks the changes throughout this test ===
-    let verifiable_group_info = alice_group
-        .export_group_info(backend, &alice_signer, false)
-        .unwrap()
-        .into_verifiable_group_info()
-        .unwrap();
-    let ratchet_tree = alice_group.export_ratchet_tree();
-    let (mut public_group, _extensions) = PublicGroup::from_external(
-        backend,
-        ratchet_tree.into(),
-        verifiable_group_info,
-        ProposalStore::new(),
-        true,
-    )
-    .await
-    .unwrap();
-
-    // === Alice adds Bob ===
-    let (message, welcome, _group_info) = alice_group
-        .add_members(
+        // === Alice creates a group ===
+        let mut alice_group = MlsGroup::new_with_group_id(
             backend,
             &alice_signer,
-            vec![bob_kpb.key_package().clone().into()],
+            &mls_group_config,
+            group_id,
+            alice_credential_with_key,
         )
         .await
-        .expect("Could not add member to group.");
+        .expect("An unexpected error occurred.");
 
-    alice_group
-        .merge_pending_commit(backend)
-        .await
-        .expect("error merging pending commit");
-
-    let public_message = match message.into_protocol_message().unwrap() {
-        ProtocolMessage::PrivateMessage(_) => panic!("Unexpected message type."),
-        ProtocolMessage::PublicMessage(public_message) => public_message,
-    };
-    let processed_message = public_group
-        .process_message(backend, public_message)
-        .await
-        .unwrap();
-
-    // Further inspection of the message can take place here ...
-    match processed_message.into_content() {
-        ProcessedMessageContent::ApplicationMessage(_)
-        | ProcessedMessageContent::ProposalMessage(_)
-        | ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
-            panic!("Unexpected message type.")
-        }
-        ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
-            // Merge the diff
-            public_group.merge_commit(*staged_commit)
-        }
-    };
-
-    // In the future, we'll use helper functions to skip the extraction steps above.
-
-    let mut bob_group = MlsGroup::new_from_welcome(
-        backend,
-        &mls_group_config,
-        welcome.into_welcome().expect("Unexpected message type."),
-        Some(alice_group.export_ratchet_tree().into()),
-    )
-    .await
-    .expect("Error creating group from Welcome");
-
-    // === Bob adds Charlie ===
-    let (queued_messages, welcome, _group_info) = bob_group
-        .add_members(
+        // === Create a public group that tracks the changes throughout this test ===
+        let verifiable_group_info = alice_group
+            .export_group_info(backend, &alice_signer, false)
+            .unwrap()
+            .into_verifiable_group_info()
+            .unwrap();
+        let ratchet_tree = alice_group.export_ratchet_tree();
+        let (mut public_group, _extensions) = PublicGroup::from_external(
             backend,
-            &bob_signer,
-            vec![charlie_kpb.key_package().clone().into()],
+            ratchet_tree.into(),
+            verifiable_group_info,
+            ProposalStore::new(),
+            true,
         )
         .await
         .unwrap();
 
-    // Alice processes
-    let alice_processed_message = alice_group
-        .process_message(
-            backend,
-            queued_messages
-                .clone()
-                .into_protocol_message()
-                .expect("Unexpected message type"),
-        )
-        .await
-        .expect("Could not process messages.");
-    if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
-        alice_processed_message.into_content()
-    {
-        alice_group
-            .merge_staged_commit(backend, *staged_commit)
+        // === Alice adds Bob ===
+        let (message, welcome, _group_info) = alice_group
+            .add_members(
+                backend,
+                &alice_signer,
+                vec![bob_kpb.key_package().clone().into()],
+            )
             .await
-            .expect("Error merging commit.");
-    } else {
-        unreachable!("Expected a StagedCommit.");
-    }
+            .expect("Could not add member to group.");
 
-    // The public group processes
-    let ppm = public_group
-        .process_message(backend, into_public_message(queued_messages))
-        .await
-        .unwrap();
-    public_group.merge_commit(extract_staged_commit(ppm));
+        alice_group
+            .merge_pending_commit(backend)
+            .await
+            .expect("error merging pending commit");
 
-    // Bob merges
-    bob_group
-        .merge_pending_commit(backend)
-        .await
-        .expect("error merging pending commit");
+        let public_message = match message.into_protocol_message().unwrap() {
+            ProtocolMessage::PrivateMessage(_) => panic!("Unexpected message type."),
+            ProtocolMessage::PublicMessage(public_message) => public_message,
+        };
+        let processed_message = public_group
+            .process_message(backend, public_message)
+            .await
+            .unwrap();
 
-    let mut charlie_group = MlsGroup::new_from_welcome(
-        backend,
-        &mls_group_config,
-        welcome.into_welcome().expect("Unexpected message type."),
-        Some(bob_group.export_ratchet_tree().into()),
-    )
-    .await
-    .expect("Error creating group from Welcome");
-
-    // === Alice removes Bob & Charlie commits ===
-
-    let (queued_messages, _) = alice_group
-        .propose_remove_member(backend, &alice_signer, LeafNodeIndex::new(1))
-        .expect("Could not propose removal");
-
-    let charlie_processed_message = charlie_group
-        .process_message(
-            backend,
-            queued_messages
-                .clone()
-                .into_protocol_message()
-                .expect("Unexpected message type"),
-        )
-        .await
-        .expect("Could not process messages.");
-
-    // The public group processes
-    let ppm = public_group
-        .process_message(backend, into_public_message(queued_messages))
-        .await
-        .unwrap();
-    // We have to add the proposal to the public group's proposal store.
-    match ppm.into_content() {
-        ProcessedMessageContent::ApplicationMessage(_)
-        | ProcessedMessageContent::ExternalJoinProposalMessage(_)
-        | ProcessedMessageContent::StagedCommitMessage(_) => panic!("Unexpected message type."),
-        ProcessedMessageContent::ProposalMessage(p) => {
-            match p.proposal() {
-                Proposal::Remove(r) => assert_eq!(r.removed(), LeafNodeIndex::new(1)),
-                _ => panic!("Unexpected proposal type"),
+        // Further inspection of the message can take place here ...
+        match processed_message.into_content() {
+            ProcessedMessageContent::ApplicationMessage(_)
+            | ProcessedMessageContent::ProposalMessage(_)
+            | ProcessedMessageContent::ExternalJoinProposalMessage(_) => {
+                panic!("Unexpected message type.")
             }
-            public_group.add_proposal(*p);
-        }
-    }
+            ProcessedMessageContent::StagedCommitMessage(staged_commit) => {
+                // Merge the diff
+                public_group.merge_commit(*staged_commit)
+            }
+        };
 
-    // Check that we received the correct proposals
-    if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
-        charlie_processed_message.into_content()
-    {
-        if let Proposal::Remove(ref remove_proposal) = staged_proposal.proposal() {
-            // Check that Bob was removed
-            assert_eq!(remove_proposal.removed(), LeafNodeIndex::new(1));
-            // Store proposal
-            charlie_group.store_pending_proposal(*staged_proposal.clone());
-        } else {
-            unreachable!("Expected a Proposal.");
-        }
+        // In the future, we'll use helper functions to skip the extraction steps above.
 
-        // Check that Alice removed Bob
-        assert!(matches!(
-            staged_proposal.sender(),
-            Sender::Member(member) if member.u32() == 0
-        ));
-    } else {
-        unreachable!("Expected a QueuedProposal.");
-    }
-
-    // Charlie commits
-    let (queued_messages, _welcome, _group_info) = charlie_group
-        .commit_to_pending_proposals(backend, &charlie_signer)
-        .await
-        .expect("Could not commit proposal");
-
-    // The public group processes
-    let ppm = public_group
-        .process_message(backend, into_public_message(queued_messages.clone()))
-        .await
-        .unwrap();
-    public_group.merge_commit(extract_staged_commit(ppm));
-
-    // Check that we receive the correct proposal
-    if let Some(staged_commit) = charlie_group.pending_commit() {
-        let remove = staged_commit
-            .remove_proposals()
-            .next()
-            .expect("Expected a proposal.");
-        // Check that Bob was removed
-        assert_eq!(remove.remove_proposal().removed().u32(), 1);
-        // Check that Alice removed Bob
-        assert!(matches!(remove.sender(), Sender::Member(member) if member.u32() == 0));
-    } else {
-        unreachable!("Expected a StagedCommit.");
-    };
-
-    charlie_group
-        .merge_pending_commit(backend)
-        .await
-        .expect("error merging pending commit");
-
-    // Alice processes
-    let alice_processed_message = alice_group
-        .process_message(
+        let mut bob_group = MlsGroup::new_from_welcome(
             backend,
-            queued_messages
-                .into_protocol_message()
-                .expect("Unexpected message type"),
+            &mls_group_config,
+            welcome.into_welcome().expect("Unexpected message type."),
+            Some(alice_group.export_ratchet_tree().into()),
         )
         .await
-        .expect("Could not process messages.");
-    if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
-        alice_processed_message.into_content()
-    {
-        alice_group
-            .merge_staged_commit(backend, *staged_commit)
-            .await
-            .expect("Error merging commit.");
-    } else {
-        unreachable!("Expected a StagedCommit.");
-    }
+        .expect("Error creating group from Welcome");
 
-    // Check that the public group state matches that of all other participants
-    assert_eq!(
-        alice_group.export_group_context(),
-        public_group.group_context()
-    );
-    assert_eq!(
-        charlie_group.export_group_context(),
-        public_group.group_context()
-    );
-    assert_eq!(
-        alice_group.export_ratchet_tree(),
-        public_group.export_ratchet_tree()
-    );
-    assert_eq!(
-        charlie_group.export_ratchet_tree(),
-        public_group.export_ratchet_tree()
-    );
+        // === Bob adds Charlie ===
+        let (queued_messages, welcome, _group_info) = bob_group
+            .add_members(
+                backend,
+                &bob_signer,
+                vec![charlie_kpb.key_package().clone().into()],
+            )
+            .await
+            .unwrap();
+
+        // Alice processes
+        let alice_processed_message = alice_group
+            .process_message(
+                backend,
+                queued_messages
+                    .clone()
+                    .into_protocol_message()
+                    .expect("Unexpected message type"),
+            )
+            .await
+            .expect("Could not process messages.");
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            alice_processed_message.into_content()
+        {
+            alice_group
+                .merge_staged_commit(backend, *staged_commit)
+                .await
+                .expect("Error merging commit.");
+        } else {
+            unreachable!("Expected a StagedCommit.");
+        }
+
+        // The public group processes
+        let ppm = public_group
+            .process_message(backend, into_public_message(queued_messages))
+            .await
+            .unwrap();
+        public_group.merge_commit(extract_staged_commit(ppm));
+
+        // Bob merges
+        bob_group
+            .merge_pending_commit(backend)
+            .await
+            .expect("error merging pending commit");
+
+        let mut charlie_group = MlsGroup::new_from_welcome(
+            backend,
+            &mls_group_config,
+            welcome.into_welcome().expect("Unexpected message type."),
+            Some(bob_group.export_ratchet_tree().into()),
+        )
+        .await
+        .expect("Error creating group from Welcome");
+
+        // === Alice removes Bob & Charlie commits ===
+
+        let (queued_messages, _) = alice_group
+            .propose_remove_member(backend, &alice_signer, LeafNodeIndex::new(1))
+            .expect("Could not propose removal");
+
+        let charlie_processed_message = charlie_group
+            .process_message(
+                backend,
+                queued_messages
+                    .clone()
+                    .into_protocol_message()
+                    .expect("Unexpected message type"),
+            )
+            .await
+            .expect("Could not process messages.");
+
+        // The public group processes
+        let ppm = public_group
+            .process_message(backend, into_public_message(queued_messages))
+            .await
+            .unwrap();
+        // We have to add the proposal to the public group's proposal store.
+        match ppm.into_content() {
+            ProcessedMessageContent::ApplicationMessage(_)
+            | ProcessedMessageContent::ExternalJoinProposalMessage(_)
+            | ProcessedMessageContent::StagedCommitMessage(_) => panic!("Unexpected message type."),
+            ProcessedMessageContent::ProposalMessage(p) => {
+                match p.proposal() {
+                    Proposal::Remove(r) => assert_eq!(r.removed(), LeafNodeIndex::new(1)),
+                    _ => panic!("Unexpected proposal type"),
+                }
+                public_group.add_proposal(*p);
+            }
+        }
+
+        // Check that we received the correct proposals
+        if let ProcessedMessageContent::ProposalMessage(staged_proposal) =
+            charlie_processed_message.into_content()
+        {
+            if let Proposal::Remove(ref remove_proposal) = staged_proposal.proposal() {
+                // Check that Bob was removed
+                assert_eq!(remove_proposal.removed(), LeafNodeIndex::new(1));
+                // Store proposal
+                charlie_group.store_pending_proposal(*staged_proposal.clone());
+            } else {
+                unreachable!("Expected a Proposal.");
+            }
+
+            // Check that Alice removed Bob
+            assert!(matches!(
+                    staged_proposal.sender(),
+                    Sender::Member(member) if member.u32() == 0
+            ));
+        } else {
+            unreachable!("Expected a QueuedProposal.");
+        }
+
+        // Charlie commits
+        let (queued_messages, _welcome, _group_info) = charlie_group
+            .commit_to_pending_proposals(backend, &charlie_signer)
+            .await
+            .expect("Could not commit proposal");
+
+        // The public group processes
+        let ppm = public_group
+            .process_message(backend, into_public_message(queued_messages.clone()))
+            .await
+            .unwrap();
+        public_group.merge_commit(extract_staged_commit(ppm));
+
+        // Check that we receive the correct proposal
+        if let Some(staged_commit) = charlie_group.pending_commit() {
+            let remove = staged_commit
+                .remove_proposals()
+                .next()
+                .expect("Expected a proposal.");
+            // Check that Bob was removed
+            assert_eq!(remove.remove_proposal().removed().u32(), 1);
+            // Check that Alice removed Bob
+            assert!(matches!(remove.sender(), Sender::Member(member) if member.u32() == 0));
+        } else {
+            unreachable!("Expected a StagedCommit.");
+        };
+
+        charlie_group
+            .merge_pending_commit(backend)
+            .await
+            .expect("error merging pending commit");
+
+        // Alice processes
+        let alice_processed_message = alice_group
+            .process_message(
+                backend,
+                queued_messages
+                    .into_protocol_message()
+                    .expect("Unexpected message type"),
+            )
+            .await
+            .expect("Could not process messages.");
+        if let ProcessedMessageContent::StagedCommitMessage(staged_commit) =
+            alice_processed_message.into_content()
+        {
+            alice_group
+                .merge_staged_commit(backend, *staged_commit)
+                .await
+                .expect("Error merging commit.");
+        } else {
+            unreachable!("Expected a StagedCommit.");
+        }
+
+        // Check that the public group state matches that of all other participants
+        assert_eq!(
+            alice_group.export_group_context(),
+            public_group.group_context()
+        );
+        assert_eq!(
+            charlie_group.export_group_context(),
+            public_group.group_context()
+        );
+        assert_eq!(
+            alice_group.export_ratchet_tree(),
+            public_group.export_ratchet_tree()
+        );
+        assert_eq!(
+            charlie_group.export_ratchet_tree(),
+            public_group.export_ratchet_tree()
+        );
+    })
+    .await
 }
 
 // A helper function

--- a/openmls/src/group/tests/external_add_proposal.rs
+++ b/openmls/src/group/tests/external_add_proposal.rs
@@ -122,117 +122,119 @@ async fn external_add_proposal_should_succeed(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
-    for policy in WIRE_FORMAT_POLICIES {
-        let ProposalValidationTestSetup {
-            alice_group,
-            bob_group,
-        } = validation_test_setup(policy, ciphersuite, backend).await;
-        let (mut alice_group, alice_signer) = alice_group;
-        let (mut bob_group, _bob_signer) = bob_group;
+    Box::pin(async move {
+        for policy in WIRE_FORMAT_POLICIES {
+            let ProposalValidationTestSetup {
+                alice_group,
+                bob_group,
+            } = validation_test_setup(policy, ciphersuite, backend).await;
+            let (mut alice_group, alice_signer) = alice_group;
+            let (mut bob_group, _bob_signer) = bob_group;
 
-        assert_eq!(alice_group.members().count(), 2);
-        assert_eq!(bob_group.members().count(), 2);
+            assert_eq!(alice_group.members().count(), 2);
+            assert_eq!(bob_group.members().count(), 2);
 
-        // A new client, Charlie, will now ask joining with an external Add proposal
-        let charlie_credential = generate_credential_with_key(
-            "Charlie".into(),
-            ciphersuite.signature_algorithm(),
-            backend,
-        )
-        .await;
+            // A new client, Charlie, will now ask joining with an external Add proposal
+            let charlie_credential = generate_credential_with_key(
+                "Charlie".into(),
+                ciphersuite.signature_algorithm(),
+                backend,
+            )
+                .await;
 
-        let charlie_kp = generate_key_package(
-            ciphersuite,
-            Extensions::empty(),
-            backend,
-            charlie_credential.clone(),
-        )
-        .await;
+            let charlie_kp = generate_key_package(
+                ciphersuite,
+                Extensions::empty(),
+                backend,
+                charlie_credential.clone(),
+            )
+                .await;
 
-        let proposal = JoinProposal::new(
-            charlie_kp.clone(),
-            alice_group.group_id().clone(),
-            alice_group.epoch(),
-            &charlie_credential.signer,
-        )
-        .unwrap();
+            let proposal = JoinProposal::new(
+                charlie_kp.clone(),
+                alice_group.group_id().clone(),
+                alice_group.epoch(),
+                &charlie_credential.signer,
+            )
+                .unwrap();
 
-        // an external proposal is always plaintext and has sender type 'new_member_proposal'
-        let verify_proposal = |msg: &PublicMessage| {
-            *msg.sender() == Sender::NewMemberProposal
-                && msg.content_type() == ContentType::Proposal
-                && matches!(msg.content(), FramedContentBody::Proposal(p) if p.proposal_type() == ProposalType::Add)
-        };
-        assert!(
-            matches!(proposal.body, MlsMessageOutBody::PublicMessage(ref msg) if verify_proposal(msg))
-        );
+            // an external proposal is always plaintext and has sender type 'new_member_proposal'
+            let verify_proposal = |msg: &PublicMessage| {
+                *msg.sender() == Sender::NewMemberProposal
+                    && msg.content_type() == ContentType::Proposal
+                    && matches!(msg.content(), FramedContentBody::Proposal(p) if p.proposal_type() == ProposalType::Add)
+            };
+            assert!(
+                matches!(proposal.body, MlsMessageOutBody::PublicMessage(ref msg) if verify_proposal(msg))
+            );
 
-        let msg = alice_group
-            .process_message(backend, proposal.clone().into_protocol_message().unwrap())
-            .await
-            .unwrap();
-
-        match msg.into_content() {
-            ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
-                assert!(matches!(proposal.sender(), Sender::NewMemberProposal));
-                assert!(matches!(
-                    proposal.proposal(),
-                    Proposal::Add(AddProposal { key_package }) if key_package == &charlie_kp
-                ));
-                alice_group.store_pending_proposal(*proposal)
-            }
-            _ => unreachable!(),
-        }
-
-        let msg = bob_group
-            .process_message(backend, proposal.into_protocol_message().unwrap())
-            .await
-            .unwrap();
-
-        match msg.into_content() {
-            ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
-                bob_group.store_pending_proposal(*proposal)
-            }
-            _ => unreachable!(),
-        }
-
-        // and Alice will commit it
-        let (commit, welcome, _group_info) = alice_group
-            .commit_to_pending_proposals(backend, &alice_signer)
-            .await
-            .unwrap();
-        alice_group.merge_pending_commit(backend).await.unwrap();
-        assert_eq!(alice_group.members().count(), 3);
-
-        // Bob will also process the commit
-        let msg = bob_group
-            .process_message(backend, commit.into_protocol_message().unwrap())
-            .await
-            .unwrap();
-        match msg.into_content() {
-            ProcessedMessageContent::StagedCommitMessage(commit) => bob_group
-                .merge_staged_commit(backend, *commit)
+            let msg = alice_group
+                .process_message(backend, proposal.clone().into_protocol_message().unwrap())
                 .await
-                .unwrap(),
-            _ => unreachable!(),
-        }
-        assert_eq!(bob_group.members().count(), 3);
+                .unwrap();
 
-        // Finally, Charlie can join with the Welcome
-        let cfg = MlsGroupConfig::builder()
-            .wire_format_policy(policy)
-            .crypto_config(CryptoConfig::with_default_version(ciphersuite))
-            .build();
-        let charlie_group = MlsGroup::new_from_welcome(
-            backend,
-            &cfg,
-            welcome.unwrap().into_welcome().unwrap(),
-            Some(alice_group.export_ratchet_tree().into()),
-        )
-        .await
-        .unwrap();
-        assert_eq!(charlie_group.members().count(), 3);
-    }
+            match msg.into_content() {
+                ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
+                    assert!(matches!(proposal.sender(), Sender::NewMemberProposal));
+                    assert!(matches!(
+                            proposal.proposal(),
+                            Proposal::Add(AddProposal { key_package }) if key_package == &charlie_kp
+                    ));
+                    alice_group.store_pending_proposal(*proposal)
+                }
+                _ => unreachable!(),
+            }
+
+            let msg = bob_group
+                .process_message(backend, proposal.into_protocol_message().unwrap())
+                .await
+                .unwrap();
+
+            match msg.into_content() {
+                ProcessedMessageContent::ExternalJoinProposalMessage(proposal) => {
+                    bob_group.store_pending_proposal(*proposal)
+                }
+                _ => unreachable!(),
+            }
+
+            // and Alice will commit it
+            let (commit, welcome, _group_info) = alice_group
+                .commit_to_pending_proposals(backend, &alice_signer)
+                .await
+                .unwrap();
+            alice_group.merge_pending_commit(backend).await.unwrap();
+            assert_eq!(alice_group.members().count(), 3);
+
+            // Bob will also process the commit
+            let msg = bob_group
+                .process_message(backend, commit.into_protocol_message().unwrap())
+                .await
+                .unwrap();
+            match msg.into_content() {
+                ProcessedMessageContent::StagedCommitMessage(commit) => bob_group
+                    .merge_staged_commit(backend, *commit)
+                    .await
+                    .unwrap(),
+                _ => unreachable!(),
+            }
+            assert_eq!(bob_group.members().count(), 3);
+
+            // Finally, Charlie can join with the Welcome
+            let cfg = MlsGroupConfig::builder()
+                .wire_format_policy(policy)
+                .crypto_config(CryptoConfig::with_default_version(ciphersuite))
+                .build();
+            let charlie_group = MlsGroup::new_from_welcome(
+                backend,
+                &cfg,
+                welcome.unwrap().into_welcome().unwrap(),
+                Some(alice_group.export_ratchet_tree().into()),
+            )
+                .await
+                .unwrap();
+            assert_eq!(charlie_group.members().count(), 3);
+        }
+    }).await
 }
 
 #[apply(ciphersuites_and_backends)]
@@ -290,90 +292,93 @@ async fn new_member_proposal_sender_should_be_reserved_for_join_proposals(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
-    let ProposalValidationTestSetup {
-        alice_group,
-        bob_group,
-    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend).await;
-    let (mut alice_group, alice_signer) = alice_group;
-    let (mut bob_group, _bob_signer) = bob_group;
+    Box::pin(async move {
+        let ProposalValidationTestSetup {
+            alice_group,
+            bob_group,
+        } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend).await;
+        let (mut alice_group, alice_signer) = alice_group;
+        let (mut bob_group, _bob_signer) = bob_group;
 
-    // Add proposal can have a 'new_member_proposal' sender
-    let any_credential =
-        generate_credential_with_key("Any".into(), ciphersuite.signature_algorithm(), backend)
-            .await;
+        // Add proposal can have a 'new_member_proposal' sender
+        let any_credential =
+            generate_credential_with_key("Any".into(), ciphersuite.signature_algorithm(), backend)
+                .await;
 
-    let any_kp = generate_key_package(
-        ciphersuite,
-        Extensions::empty(),
-        backend,
-        any_credential.clone(),
-    )
-    .await;
+        let any_kp = generate_key_package(
+            ciphersuite,
+            Extensions::empty(),
+            backend,
+            any_credential.clone(),
+        )
+        .await;
 
-    let join_proposal = JoinProposal::new(
-        any_kp,
-        alice_group.group_id().clone(),
-        alice_group.epoch(),
-        &any_credential.signer,
-    )
-    .unwrap();
+        let join_proposal = JoinProposal::new(
+            any_kp,
+            alice_group.group_id().clone(),
+            alice_group.epoch(),
+            &any_credential.signer,
+        )
+        .unwrap();
 
-    if let MlsMessageOutBody::PublicMessage(plaintext) = &join_proposal.body {
-        // Make sure it's an add proposal...
-        assert!(matches!(
-            plaintext.content(),
-            FramedContentBody::Proposal(Proposal::Add(_))
-        ));
+        if let MlsMessageOutBody::PublicMessage(plaintext) = &join_proposal.body {
+            // Make sure it's an add proposal...
+            assert!(matches!(
+                plaintext.content(),
+                FramedContentBody::Proposal(Proposal::Add(_))
+            ));
 
-        // ... and that it has the right sender type
-        assert!(matches!(plaintext.sender(), Sender::NewMemberProposal));
+            // ... and that it has the right sender type
+            assert!(matches!(plaintext.sender(), Sender::NewMemberProposal));
 
-        // Finally check that the message can be processed without errors
-        assert!(bob_group
-            .process_message(backend, join_proposal.into_protocol_message().unwrap())
+            // Finally check that the message can be processed without errors
+            assert!(bob_group
+                .process_message(backend, join_proposal.into_protocol_message().unwrap())
+                .await
+                .is_ok());
+        } else {
+            panic!()
+        };
+        alice_group.clear_pending_proposals();
+
+        // Remove proposal cannot have a 'new_member_proposal' sender
+        let remove_proposal = alice_group
+            .propose_remove_member(backend, &alice_signer, LeafNodeIndex::new(1))
+            .map(|(out, _)| MlsMessageIn::from(out))
+            .unwrap();
+        if let MlsMessageInBody::PublicMessage(mut plaintext) = remove_proposal.body {
+            plaintext.set_sender(Sender::NewMemberProposal);
+            assert!(matches!(
+                bob_group
+                    .process_message(backend, plaintext)
+                    .await
+                    .unwrap_err(),
+                ProcessMessageError::ValidationError(ValidationError::NotAnExternalAddProposal)
+            ));
+        } else {
+            panic!()
+        };
+        alice_group.clear_pending_proposals();
+
+        // Update proposal cannot have a 'new_member_proposal' sender
+        let update_proposal = alice_group
+            .propose_self_update(backend, &alice_signer)
             .await
-            .is_ok());
-    } else {
-        panic!()
-    };
-    alice_group.clear_pending_proposals();
-
-    // Remove proposal cannot have a 'new_member_proposal' sender
-    let remove_proposal = alice_group
-        .propose_remove_member(backend, &alice_signer, LeafNodeIndex::new(1))
-        .map(|(out, _)| MlsMessageIn::from(out))
-        .unwrap();
-    if let MlsMessageInBody::PublicMessage(mut plaintext) = remove_proposal.body {
-        plaintext.set_sender(Sender::NewMemberProposal);
-        assert!(matches!(
-            bob_group
-                .process_message(backend, plaintext)
-                .await
-                .unwrap_err(),
-            ProcessMessageError::ValidationError(ValidationError::NotAnExternalAddProposal)
-        ));
-    } else {
-        panic!()
-    };
-    alice_group.clear_pending_proposals();
-
-    // Update proposal cannot have a 'new_member_proposal' sender
-    let update_proposal = alice_group
-        .propose_self_update(backend, &alice_signer)
-        .await
-        .map(|(out, _)| MlsMessageIn::from(out))
-        .unwrap();
-    if let MlsMessageInBody::PublicMessage(mut plaintext) = update_proposal.body {
-        plaintext.set_sender(Sender::NewMemberProposal);
-        assert!(matches!(
-            bob_group
-                .process_message(backend, plaintext)
-                .await
-                .unwrap_err(),
-            ProcessMessageError::ValidationError(ValidationError::NotAnExternalAddProposal)
-        ));
-    } else {
-        panic!()
-    };
-    alice_group.clear_pending_proposals();
+            .map(|(out, _)| MlsMessageIn::from(out))
+            .unwrap();
+        if let MlsMessageInBody::PublicMessage(mut plaintext) = update_proposal.body {
+            plaintext.set_sender(Sender::NewMemberProposal);
+            assert!(matches!(
+                bob_group
+                    .process_message(backend, plaintext)
+                    .await
+                    .unwrap_err(),
+                ProcessMessageError::ValidationError(ValidationError::NotAnExternalAddProposal)
+            ));
+        } else {
+            panic!()
+        };
+        alice_group.clear_pending_proposals();
+    })
+    .await
 }

--- a/openmls/src/group/tests/test_proposal_validation.rs
+++ b/openmls/src/group/tests/test_proposal_validation.rs
@@ -1828,170 +1828,173 @@ async fn test_valsem110(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoPr
 #[apply(ciphersuites_and_backends)]
 #[wasm_bindgen_test::wasm_bindgen_test]
 async fn test_valsem111(ciphersuite: Ciphersuite, backend: &impl OpenMlsCryptoProvider) {
-    // Before we can test creation or reception of (invalid) proposals, we set
-    // up a new group with Alice and Bob.
-    let ProposalValidationTestSetup {
-        mut alice_group,
-        alice_credential_with_key_and_signer,
-        mut bob_group,
-        ..
-    } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend).await;
+    Box::pin(async move {
+        // Before we can test creation or reception of (invalid) proposals, we set
+        // up a new group with Alice and Bob.
+        let ProposalValidationTestSetup {
+            mut alice_group,
+            alice_credential_with_key_and_signer,
+            mut bob_group,
+            ..
+        } = validation_test_setup(PURE_PLAINTEXT_WIRE_FORMAT_POLICY, ciphersuite, backend).await;
 
-    // We can't test this by having Alice propose an update herself. This is due
-    // to the commit logic filtering out own proposals and just including a path
-    // instead.
+        // We can't test this by having Alice propose an update herself. This is due
+        // to the commit logic filtering out own proposals and just including a path
+        // instead.
 
-    // However, we can test the receiving side by crafting such a commit
-    // manually. We have to test two scenarios: One, where the proposal is
-    // inline and one, where it's committed by reference.
+        // However, we can test the receiving side by crafting such a commit
+        // manually. We have to test two scenarios: One, where the proposal is
+        // inline and one, where it's committed by reference.
 
-    // We begin by creating an update proposal for alice.
-    let update_kp = generate_key_package(
-        ciphersuite,
-        Extensions::empty(),
-        backend,
-        alice_credential_with_key_and_signer.clone(),
-    )
-    .await;
-
-    let update_proposal = Proposal::Update(UpdateProposal {
-        leaf_node: update_kp.leaf_node().clone(),
-    });
-
-    // We now have Alice create a commit. That commit should not contain any
-    // proposals, just a path.
-    let commit = alice_group
-        .self_update(backend, &alice_credential_with_key_and_signer.signer)
-        .await
-        .expect("Error creating self-update");
-
-    // Check that there's no proposal in it.
-    let serialized_message = commit
-        .tls_serialize_detached()
-        .expect("error serializing plaintext");
-
-    let plaintext = MlsMessageIn::tls_deserialize(&mut serialized_message.as_slice())
-        .expect("Could not deserialize message.")
-        .into_plaintext()
-        .expect("Message was not a plaintext.");
-
-    let commit_content = if let FramedContentBody::Commit(commit) = plaintext.content() {
-        commit.clone()
-    } else {
-        panic!("Unexpected content type.");
-    };
-
-    // The commit should contain no proposals.
-    assert_eq!(commit_content.proposals.len(), 0);
-
-    let serialized_update = commit
-        .tls_serialize_detached()
-        .expect("Could not serialize message.");
-
-    let plaintext = MlsMessageIn::tls_deserialize(&mut serialized_update.as_slice())
-        .expect("Could not deserialize message.")
-        .into_plaintext()
-        .expect("Message was not a plaintext.");
-
-    // Keep the original plaintext for positive test later.
-    let original_plaintext = plaintext.clone();
-
-    // Let's insert the proposal into the commit.
-    let verifiable_plaintext = insert_proposal_and_resign(
-        backend,
-        vec![ProposalOrRef::Proposal(update_proposal.clone())],
-        plaintext,
-        &original_plaintext,
-        &alice_group,
-        &alice_credential_with_key_and_signer.signer,
-    );
-
-    let update_message_in = ProtocolMessage::from(verifiable_plaintext);
-
-    // Have bob process the resulting plaintext
-    let err = bob_group
-        .process_message(backend, update_message_in)
-        .await
-        .expect_err("Could process message despite modified public key in path.");
-
-    assert_eq!(
-        err,
-        ProcessMessageError::ValidationError(ValidationError::CommitterIncludedOwnUpdate)
-    );
-
-    // Now we insert the proposal into Bob's proposal store so we can include it
-    // in the commit by reference.
-    bob_group.store_pending_proposal(
-        QueuedProposal::from_proposal_and_sender(
+        // We begin by creating an update proposal for alice.
+        let update_kp = generate_key_package(
             ciphersuite,
+            Extensions::empty(),
             backend,
-            update_proposal.clone(),
-            &Sender::build_member(alice_group.own_leaf_index()),
+            alice_credential_with_key_and_signer.clone(),
         )
-        .expect("error creating queued proposal"),
-    );
+        .await;
 
-    // Now we can have Alice create a new commit and insert the proposal by
-    // reference.
+        let update_proposal = Proposal::Update(UpdateProposal {
+            leaf_node: update_kp.leaf_node().clone(),
+        });
 
-    // Wipe any pending commit first.
-    alice_group.clear_pending_commit();
+        // We now have Alice create a commit. That commit should not contain any
+        // proposals, just a path.
+        let commit = alice_group
+            .self_update(backend, &alice_credential_with_key_and_signer.signer)
+            .await
+            .expect("Error creating self-update");
 
-    let commit = alice_group
-        .self_update(backend, &alice_credential_with_key_and_signer.signer)
-        .await
-        .expect("Error creating self-update");
+        // Check that there's no proposal in it.
+        let serialized_message = commit
+            .tls_serialize_detached()
+            .expect("error serializing plaintext");
 
-    let serialized_update = commit
-        .tls_serialize_detached()
-        .expect("Could not serialize message.");
+        let plaintext = MlsMessageIn::tls_deserialize(&mut serialized_message.as_slice())
+            .expect("Could not deserialize message.")
+            .into_plaintext()
+            .expect("Message was not a plaintext.");
 
-    let plaintext = MlsMessageIn::tls_deserialize(&mut serialized_update.as_slice())
-        .expect("Could not deserialize message.")
-        .into_plaintext()
-        .expect("Message was not a plaintext.");
+        let commit_content = if let FramedContentBody::Commit(commit) = plaintext.content() {
+            commit.clone()
+        } else {
+            panic!("Unexpected content type.");
+        };
 
-    // Keep the original plaintext for positive test later.
-    let original_plaintext = plaintext.clone();
+        // The commit should contain no proposals.
+        assert_eq!(commit_content.proposals.len(), 0);
 
-    // Let's insert the proposal into the commit.
-    // Artificially add the proposal.
-    let verifiable_plaintext = insert_proposal_and_resign(
-        backend,
-        vec![ProposalOrRef::Reference(
-            ProposalRef::from_raw_proposal(ciphersuite, backend, &update_proposal)
-                .expect("error creating hash reference"),
-        )],
-        plaintext,
-        &original_plaintext,
-        &alice_group,
-        &alice_credential_with_key_and_signer.signer,
-    );
+        let serialized_update = commit
+            .tls_serialize_detached()
+            .expect("Could not serialize message.");
 
-    let update_message_in = ProtocolMessage::from(verifiable_plaintext);
+        let plaintext = MlsMessageIn::tls_deserialize(&mut serialized_update.as_slice())
+            .expect("Could not deserialize message.")
+            .into_plaintext()
+            .expect("Message was not a plaintext.");
 
-    // Have bob process the resulting plaintext
-    let err = bob_group
-        .process_message(backend, update_message_in)
-        .await
-        .expect_err("Could process message despite modified public key in path.");
+        // Keep the original plaintext for positive test later.
+        let original_plaintext = plaintext.clone();
 
-    assert_eq!(
-        err,
-        ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
-            ProposalValidationError::CommitterIncludedOwnUpdate
-        ))
-    );
+        // Let's insert the proposal into the commit.
+        let verifiable_plaintext = insert_proposal_and_resign(
+            backend,
+            vec![ProposalOrRef::Proposal(update_proposal.clone())],
+            plaintext,
+            &original_plaintext,
+            &alice_group,
+            &alice_credential_with_key_and_signer.signer,
+        );
 
-    let original_update_plaintext =
-        MlsMessageIn::tls_deserialize(&mut serialized_update.as_slice())
-            .expect("Could not deserialize message.");
+        let update_message_in = ProtocolMessage::from(verifiable_plaintext);
 
-    // Positive case
-    bob_group
-        .process_message(backend, original_update_plaintext)
-        .await
-        .expect("Unexpected error.");
+        // Have bob process the resulting plaintext
+        let err = bob_group
+            .process_message(backend, update_message_in)
+            .await
+            .expect_err("Could process message despite modified public key in path.");
+
+        assert_eq!(
+            err,
+            ProcessMessageError::ValidationError(ValidationError::CommitterIncludedOwnUpdate)
+        );
+
+        // Now we insert the proposal into Bob's proposal store so we can include it
+        // in the commit by reference.
+        bob_group.store_pending_proposal(
+            QueuedProposal::from_proposal_and_sender(
+                ciphersuite,
+                backend,
+                update_proposal.clone(),
+                &Sender::build_member(alice_group.own_leaf_index()),
+            )
+            .expect("error creating queued proposal"),
+        );
+
+        // Now we can have Alice create a new commit and insert the proposal by
+        // reference.
+
+        // Wipe any pending commit first.
+        alice_group.clear_pending_commit();
+
+        let commit = alice_group
+            .self_update(backend, &alice_credential_with_key_and_signer.signer)
+            .await
+            .expect("Error creating self-update");
+
+        let serialized_update = commit
+            .tls_serialize_detached()
+            .expect("Could not serialize message.");
+
+        let plaintext = MlsMessageIn::tls_deserialize(&mut serialized_update.as_slice())
+            .expect("Could not deserialize message.")
+            .into_plaintext()
+            .expect("Message was not a plaintext.");
+
+        // Keep the original plaintext for positive test later.
+        let original_plaintext = plaintext.clone();
+
+        // Let's insert the proposal into the commit.
+        // Artificially add the proposal.
+        let verifiable_plaintext = insert_proposal_and_resign(
+            backend,
+            vec![ProposalOrRef::Reference(
+                ProposalRef::from_raw_proposal(ciphersuite, backend, &update_proposal)
+                    .expect("error creating hash reference"),
+            )],
+            plaintext,
+            &original_plaintext,
+            &alice_group,
+            &alice_credential_with_key_and_signer.signer,
+        );
+
+        let update_message_in = ProtocolMessage::from(verifiable_plaintext);
+
+        // Have bob process the resulting plaintext
+        let err = bob_group
+            .process_message(backend, update_message_in)
+            .await
+            .expect_err("Could process message despite modified public key in path.");
+
+        assert_eq!(
+            err,
+            ProcessMessageError::InvalidCommit(StageCommitError::ProposalValidationError(
+                ProposalValidationError::CommitterIncludedOwnUpdate
+            ))
+        );
+
+        let original_update_plaintext =
+            MlsMessageIn::tls_deserialize(&mut serialized_update.as_slice())
+                .expect("Could not deserialize message.");
+
+        // Positive case
+        bob_group
+            .process_message(backend, original_update_plaintext)
+            .await
+            .expect("Unexpected error.");
+    })
+    .await
 }
 
 /// ValSem112

--- a/openmls/src/group/tests/test_remove_operation.rs
+++ b/openmls/src/group/tests/test_remove_operation.rs
@@ -17,302 +17,305 @@ async fn test_remove_operation_variants(
     ciphersuite: Ciphersuite,
     backend: &impl OpenMlsCryptoProvider,
 ) {
-    let _ = backend;
-    let alice_backend = OpenMlsRustCrypto::default();
-    let bob_backend = OpenMlsRustCrypto::default();
-    let charlie_backend = OpenMlsRustCrypto::default();
+    Box::pin(async move {
+        let _ = backend;
+        let alice_backend = OpenMlsRustCrypto::default();
+        let bob_backend = OpenMlsRustCrypto::default();
+        let charlie_backend = OpenMlsRustCrypto::default();
 
-    // We define two test cases, one where the member is removed by another member
-    // and one where the member leaves the group on its own
-    enum TestCase {
-        Remove,
-        Leave,
-    }
+        // We define two test cases, one where the member is removed by another member
+        // and one where the member leaves the group on its own
+        enum TestCase {
+            Remove,
+            Leave,
+        }
 
-    for test_case in [TestCase::Remove, TestCase::Leave] {
-        let group_id = GroupId::from_slice(b"Test Group");
+        for test_case in [TestCase::Remove, TestCase::Leave] {
+            let group_id = GroupId::from_slice(b"Test Group");
 
-        // Generate credentials with keys
-        let alice_credential_with_key_and_signer = generate_credential_with_key(
-            "Alice".into(),
-            ciphersuite.signature_algorithm(),
-            &alice_backend,
-        )
-        .await;
+            // Generate credentials with keys
+            let alice_credential_with_key_and_signer = generate_credential_with_key(
+                "Alice".into(),
+                ciphersuite.signature_algorithm(),
+                &alice_backend,
+            )
+            .await;
 
-        let bob_credential_with_key_and_signer = generate_credential_with_key(
-            "Bob".into(),
-            ciphersuite.signature_algorithm(),
-            &bob_backend,
-        )
-        .await;
+            let bob_credential_with_key_and_signer = generate_credential_with_key(
+                "Bob".into(),
+                ciphersuite.signature_algorithm(),
+                &bob_backend,
+            )
+            .await;
 
-        let charlie_credential_with_key_and_signer = generate_credential_with_key(
-            "Charlie".into(),
-            ciphersuite.signature_algorithm(),
-            &charlie_backend,
-        )
-        .await;
+            let charlie_credential_with_key_and_signer = generate_credential_with_key(
+                "Charlie".into(),
+                ciphersuite.signature_algorithm(),
+                &charlie_backend,
+            )
+            .await;
 
-        // Generate KeyPackages
-        let bob_key_package = generate_key_package(
-            ciphersuite,
-            Extensions::empty(),
-            &bob_backend,
-            bob_credential_with_key_and_signer.clone(),
-        )
-        .await;
-        let charlie_key_package = generate_key_package(
-            ciphersuite,
-            Extensions::empty(),
-            &charlie_backend,
-            charlie_credential_with_key_and_signer,
-        )
-        .await;
+            // Generate KeyPackages
+            let bob_key_package = generate_key_package(
+                ciphersuite,
+                Extensions::empty(),
+                &bob_backend,
+                bob_credential_with_key_and_signer.clone(),
+            )
+            .await;
+            let charlie_key_package = generate_key_package(
+                ciphersuite,
+                Extensions::empty(),
+                &charlie_backend,
+                charlie_credential_with_key_and_signer,
+            )
+            .await;
 
-        // Define the MlsGroup configuration
-        let mls_group_config = MlsGroupConfigBuilder::new()
-            .crypto_config(CryptoConfig::with_default_version(ciphersuite))
-            .build();
+            // Define the MlsGroup configuration
+            let mls_group_config = MlsGroupConfigBuilder::new()
+                .crypto_config(CryptoConfig::with_default_version(ciphersuite))
+                .build();
 
-        // === Alice creates a group ===
-        let mut alice_group = MlsGroup::new_with_group_id(
-            &alice_backend,
-            &alice_credential_with_key_and_signer.signer,
-            &mls_group_config,
-            group_id,
-            alice_credential_with_key_and_signer.credential_with_key,
-        )
-        .await
-        .expect("An unexpected error occurred.");
-
-        // === Alice adds Bob & Charlie ===
-
-        let (_message, welcome, _group_info) = alice_group
-            .add_members(
+            // === Alice creates a group ===
+            let mut alice_group = MlsGroup::new_with_group_id(
                 &alice_backend,
                 &alice_credential_with_key_and_signer.signer,
-                vec![bob_key_package.into(), charlie_key_package.into()],
+                &mls_group_config,
+                group_id,
+                alice_credential_with_key_and_signer.credential_with_key,
             )
             .await
             .expect("An unexpected error occurred.");
-        alice_group
-            .merge_pending_commit(&alice_backend)
-            .await
-            .expect("error merging pending commit");
 
-        let welcome = welcome.into_welcome().expect("Unexpected message type.");
+            // === Alice adds Bob & Charlie ===
 
-        let mut bob_group = MlsGroup::new_from_welcome(
-            &bob_backend,
-            &mls_group_config,
-            welcome.clone(),
-            Some(alice_group.export_ratchet_tree().into()),
-        )
-        .await
-        .expect("Error creating group from Welcome");
-
-        let mut charlie_group = MlsGroup::new_from_welcome(
-            &charlie_backend,
-            &mls_group_config,
-            welcome,
-            Some(alice_group.export_ratchet_tree().into()),
-        )
-        .await
-        .expect("Error creating group from Welcome");
-
-        // === Remove operation ===
-
-        let alice_index = alice_group.own_leaf_index();
-        let bob_index = bob_group.own_leaf_index();
-
-        // We differentiate between the two test cases here
-        let (message, _welcome, _group_info) = match test_case {
-            // Alice removes Bob
-            TestCase::Remove => alice_group
-                .remove_members(
+            let (_message, welcome, _group_info) = alice_group
+                .add_members(
                     &alice_backend,
                     &alice_credential_with_key_and_signer.signer,
-                    &[bob_index],
+                    vec![bob_key_package.into(), charlie_key_package.into()],
                 )
                 .await
-                .expect("Could not remove members."),
-            // Bob leaves
-            TestCase::Leave => {
-                // Bob leaves the group
-                let message = bob_group
-                    .leave_group(&bob_backend, &bob_credential_with_key_and_signer.signer)
-                    .expect("Could not leave group.");
+                .expect("An unexpected error occurred.");
+            alice_group
+                .merge_pending_commit(&alice_backend)
+                .await
+                .expect("error merging pending commit");
 
-                // Alice & Charlie store the pending proposal
-                for group in [&mut alice_group, &mut charlie_group] {
-                    let processed_message = group
-                        .process_message(
-                            &charlie_backend,
-                            message.clone().into_protocol_message().unwrap(),
+            let welcome = welcome.into_welcome().expect("Unexpected message type.");
+
+            let mut bob_group = MlsGroup::new_from_welcome(
+                &bob_backend,
+                &mls_group_config,
+                welcome.clone(),
+                Some(alice_group.export_ratchet_tree().into()),
+            )
+            .await
+            .expect("Error creating group from Welcome");
+
+            let mut charlie_group = MlsGroup::new_from_welcome(
+                &charlie_backend,
+                &mls_group_config,
+                welcome,
+                Some(alice_group.export_ratchet_tree().into()),
+            )
+            .await
+            .expect("Error creating group from Welcome");
+
+            // === Remove operation ===
+
+            let alice_index = alice_group.own_leaf_index();
+            let bob_index = bob_group.own_leaf_index();
+
+            // We differentiate between the two test cases here
+            let (message, _welcome, _group_info) = match test_case {
+                // Alice removes Bob
+                TestCase::Remove => alice_group
+                    .remove_members(
+                        &alice_backend,
+                        &alice_credential_with_key_and_signer.signer,
+                        &[bob_index],
+                    )
+                    .await
+                    .expect("Could not remove members."),
+                // Bob leaves
+                TestCase::Leave => {
+                    // Bob leaves the group
+                    let message = bob_group
+                        .leave_group(&bob_backend, &bob_credential_with_key_and_signer.signer)
+                        .expect("Could not leave group.");
+
+                    // Alice & Charlie store the pending proposal
+                    for group in [&mut alice_group, &mut charlie_group] {
+                        let processed_message = group
+                            .process_message(
+                                &charlie_backend,
+                                message.clone().into_protocol_message().unwrap(),
+                            )
+                            .await
+                            .expect("Could not process message.");
+
+                        match processed_message.into_content() {
+                            ProcessedMessageContent::ProposalMessage(proposal) => {
+                                group.store_pending_proposal(*proposal);
+                            }
+                            _ => unreachable!(),
+                        }
+                    }
+
+                    // Alice commits to Bob's proposal
+                    alice_group
+                        .commit_to_pending_proposals(
+                            &alice_backend,
+                            &alice_credential_with_key_and_signer.signer,
                         )
                         .await
-                        .expect("Could not process message.");
+                        .expect("An unexpected error occurred.")
+                }
+            };
 
-                    match processed_message.into_content() {
-                        ProcessedMessageContent::ProposalMessage(proposal) => {
-                            group.store_pending_proposal(*proposal);
+            // === Remove operation from Alice's perspective ===
+
+            let alice_staged_commit = alice_group.pending_commit().expect("No pending commit.");
+
+            let remove_proposal = alice_staged_commit
+                .remove_proposals()
+                .next()
+                .expect("An unexpected error occurred.");
+
+            let remove_operation = RemoveOperation::new(remove_proposal, &alice_group)
+                .expect("An unexpected Error occurred.");
+
+            match test_case {
+                TestCase::Remove => {
+                    // We expect this variant, since Alice removed Bob
+                    match remove_operation {
+                        RemoveOperation::WeRemovedThem(removed) => {
+                            // Check that it was indeed Bob who was removed
+                            assert_eq!(removed, bob_index);
                         }
                         _ => unreachable!(),
                     }
                 }
-
-                // Alice commits to Bob's proposal
-                alice_group
-                    .commit_to_pending_proposals(
-                        &alice_backend,
-                        &alice_credential_with_key_and_signer.signer,
-                    )
-                    .await
-                    .expect("An unexpected error occurred.")
-            }
-        };
-
-        // === Remove operation from Alice's perspective ===
-
-        let alice_staged_commit = alice_group.pending_commit().expect("No pending commit.");
-
-        let remove_proposal = alice_staged_commit
-            .remove_proposals()
-            .next()
-            .expect("An unexpected error occurred.");
-
-        let remove_operation = RemoveOperation::new(remove_proposal, &alice_group)
-            .expect("An unexpected Error occurred.");
-
-        match test_case {
-            TestCase::Remove => {
-                // We expect this variant, since Alice removed Bob
-                match remove_operation {
-                    RemoveOperation::WeRemovedThem(removed) => {
-                        // Check that it was indeed Bob who was removed
-                        assert_eq!(removed, bob_index);
+                TestCase::Leave => {
+                    // We expect this variant, since Bob left
+                    match remove_operation {
+                        RemoveOperation::TheyLeft(removed) => {
+                            // Check that it was indeed Bob who left
+                            assert_eq!(removed, bob_index);
+                        }
+                        _ => unreachable!(),
                     }
-                    _ => unreachable!(),
                 }
             }
-            TestCase::Leave => {
-                // We expect this variant, since Bob left
-                match remove_operation {
-                    RemoveOperation::TheyLeft(removed) => {
-                        // Check that it was indeed Bob who left
-                        assert_eq!(removed, bob_index);
-                    }
-                    _ => unreachable!(),
-                }
-            }
-        }
 
-        // === Remove operation from Bob's perspective ===
+            // === Remove operation from Bob's perspective ===
 
-        let bob_processed_message = bob_group
-            .process_message(
-                &bob_backend,
-                message.clone().into_protocol_message().unwrap(),
-            )
-            .await
-            .expect("Could not process message.");
+            let bob_processed_message = bob_group
+                .process_message(
+                    &bob_backend,
+                    message.clone().into_protocol_message().unwrap(),
+                )
+                .await
+                .expect("Could not process message.");
 
-        match bob_processed_message.into_content() {
-            ProcessedMessageContent::StagedCommitMessage(bob_staged_commit) => {
-                let remove_proposal = bob_staged_commit
-                    .remove_proposals()
-                    .next()
-                    .expect("An unexpected error occurred.");
+            match bob_processed_message.into_content() {
+                ProcessedMessageContent::StagedCommitMessage(bob_staged_commit) => {
+                    let remove_proposal = bob_staged_commit
+                        .remove_proposals()
+                        .next()
+                        .expect("An unexpected error occurred.");
 
-                let remove_operation = RemoveOperation::new(remove_proposal, &bob_group)
-                    .expect("An unexpected Error occurred.");
+                    let remove_operation = RemoveOperation::new(remove_proposal, &bob_group)
+                        .expect("An unexpected Error occurred.");
 
-                match test_case {
-                    TestCase::Remove => {
-                        // We expect this variant, since Alice removed Bob
-                        match remove_operation {
-                            RemoveOperation::WeWereRemovedBy(sender) => {
-                                // Make sure Alice is indeed a member
-                                assert!(sender.is_member());
-                                // Check Bob was removed
-                                assert!(bob_staged_commit.self_removed());
-                                match sender {
-                                    Sender::Member(member) => {
-                                        // Check that it was Alice who removed Bob
-                                        assert_eq!(member, alice_index);
+                    match test_case {
+                        TestCase::Remove => {
+                            // We expect this variant, since Alice removed Bob
+                            match remove_operation {
+                                RemoveOperation::WeWereRemovedBy(sender) => {
+                                    // Make sure Alice is indeed a member
+                                    assert!(sender.is_member());
+                                    // Check Bob was removed
+                                    assert!(bob_staged_commit.self_removed());
+                                    match sender {
+                                        Sender::Member(member) => {
+                                            // Check that it was Alice who removed Bob
+                                            assert_eq!(member, alice_index);
+                                        }
+                                        _ => unreachable!(),
                                     }
-                                    _ => unreachable!(),
                                 }
+                                _ => unreachable!(),
                             }
-                            _ => unreachable!(),
                         }
-                    }
-                    TestCase::Leave => {
-                        // We expect this variant, since Bob left
-                        match remove_operation {
-                            RemoveOperation::WeLeft => {
-                                // Check that Bob is no longer part of the group
-                                assert!(bob_staged_commit.self_removed());
+                        TestCase::Leave => {
+                            // We expect this variant, since Bob left
+                            match remove_operation {
+                                RemoveOperation::WeLeft => {
+                                    // Check that Bob is no longer part of the group
+                                    assert!(bob_staged_commit.self_removed());
+                                }
+                                _ => unreachable!(),
                             }
-                            _ => unreachable!(),
                         }
                     }
                 }
+                _ => unreachable!(),
             }
-            _ => unreachable!(),
-        }
 
-        // === Remove operation from Charlie's perspective ===
+            // === Remove operation from Charlie's perspective ===
 
-        let charlie_processed_message = charlie_group
-            .process_message(&charlie_backend, message.into_protocol_message().unwrap())
-            .await
-            .expect("Could not process message.");
+            let charlie_processed_message = charlie_group
+                .process_message(&charlie_backend, message.into_protocol_message().unwrap())
+                .await
+                .expect("Could not process message.");
 
-        match charlie_processed_message.into_content() {
-            ProcessedMessageContent::StagedCommitMessage(charlie_staged_commit) => {
-                let remove_proposal = charlie_staged_commit
-                    .remove_proposals()
-                    .next()
-                    .expect("An unexpected error occurred.");
+            match charlie_processed_message.into_content() {
+                ProcessedMessageContent::StagedCommitMessage(charlie_staged_commit) => {
+                    let remove_proposal = charlie_staged_commit
+                        .remove_proposals()
+                        .next()
+                        .expect("An unexpected error occurred.");
 
-                let remove_operation = RemoveOperation::new(remove_proposal, &charlie_group)
-                    .expect("An unexpected Error occurred.");
+                    let remove_operation = RemoveOperation::new(remove_proposal, &charlie_group)
+                        .expect("An unexpected Error occurred.");
 
-                match test_case {
-                    TestCase::Remove => {
-                        // We expect this variant, since Alice removed Bob
-                        match remove_operation {
-                            RemoveOperation::TheyWereRemovedBy((removed, sender)) => {
-                                // Make sure Alice is indeed a member
-                                assert!(sender.is_member());
-                                // Check that it was indeed Bob who was removed
-                                assert_eq!(removed, bob_index);
-                                match sender {
-                                    Sender::Member(member) => {
-                                        // Check that it was Alice who removed Bob
-                                        assert_eq!(member, alice_index);
+                    match test_case {
+                        TestCase::Remove => {
+                            // We expect this variant, since Alice removed Bob
+                            match remove_operation {
+                                RemoveOperation::TheyWereRemovedBy((removed, sender)) => {
+                                    // Make sure Alice is indeed a member
+                                    assert!(sender.is_member());
+                                    // Check that it was indeed Bob who was removed
+                                    assert_eq!(removed, bob_index);
+                                    match sender {
+                                        Sender::Member(member) => {
+                                            // Check that it was Alice who removed Bob
+                                            assert_eq!(member, alice_index);
+                                        }
+                                        _ => unreachable!(),
                                     }
-                                    _ => unreachable!(),
                                 }
+                                _ => unreachable!(),
                             }
-                            _ => unreachable!(),
                         }
-                    }
-                    TestCase::Leave => {
-                        // We expect this variant, since Bob left
-                        match remove_operation {
-                            RemoveOperation::TheyLeft(removed) => {
-                                // Check that it was indeed Bob who left
-                                assert_eq!(removed, bob_index);
+                        TestCase::Leave => {
+                            // We expect this variant, since Bob left
+                            match remove_operation {
+                                RemoveOperation::TheyLeft(removed) => {
+                                    // Check that it was indeed Bob who left
+                                    assert_eq!(removed, bob_index);
+                                }
+                                _ => unreachable!(),
                             }
-                            _ => unreachable!(),
                         }
                     }
                 }
+                _ => unreachable!(),
             }
-            _ => unreachable!(),
         }
-    }
+    })
+    .await
 }

--- a/openmls/src/group/tests/utils.rs
+++ b/openmls/src/group/tests/utils.rs
@@ -13,7 +13,7 @@ use openmls_basic_credential::SignatureKeyPair;
 use openmls_traits::{
     key_store::OpenMlsKeyStore, signatures::Signer, types::SignatureScheme, OpenMlsCryptoProvider,
 };
-use rand::{rngs::OsRng, RngCore};
+use rand::Rng as _;
 use tls_codec::Serialize;
 
 use crate::{
@@ -295,13 +295,13 @@ pub(crate) async fn setup(
 }
 
 pub fn random_usize() -> usize {
-    OsRng.next_u64() as usize
+    rand::rng().next_u64() as usize
 }
 
 /// No crypto randomness!
 pub fn randombytes(n: usize) -> Vec<u8> {
     let mut out = vec![0u8; n];
-    OsRng.fill_bytes(&mut out);
+    rand::rng().fill_bytes(&mut out);
     out
 }
 

--- a/openmls/src/test_utils/test_framework/mod.rs
+++ b/openmls/src/test_utils/test_framework/mod.rs
@@ -31,7 +31,6 @@ use crate::{
     messages::*,
     treesync::{node::Node, LeafNode, RatchetTree, RatchetTreeIn},
 };
-use ::rand::{rngs::OsRng, RngCore};
 use async_lock::RwLock;
 use openmls_basic_credential::SignatureKeyPair;
 use openmls_rust_crypto::OpenMlsRustCrypto;
@@ -42,6 +41,7 @@ use openmls_traits::{
     types::{Ciphersuite, HpkeKeyPair, SignatureScheme},
     OpenMlsCryptoProvider,
 };
+use rand::Rng as _;
 use std::collections::HashMap;
 use tls_codec::{Deserialize as _, Serialize as _};
 
@@ -69,7 +69,7 @@ pub struct Group {
 impl Group {
     /// Return the identity of a random member of the group.
     pub fn random_group_member(&self) -> (u32, Vec<u8>) {
-        let index = (OsRng.next_u32() as usize) % self.members.len();
+        let index = (rand::rng().next_u32() as usize) % self.members.len();
         let (i, identity) = self.members[index].clone();
         (i as u32, identity)
     }
@@ -440,7 +440,7 @@ impl MlsGroupTestSetup {
     pub async fn create_group(&self, ciphersuite: Ciphersuite) -> Result<GroupId, SetupError> {
         // Pick a random group creator.
         let clients = self.clients.read().await;
-        let group_creator_id = ((OsRng.next_u32() as usize) % clients.len())
+        let group_creator_id = ((rand::rng().next_u32() as usize) % clients.len())
             .to_be_bytes()
             .to_vec();
         let group_creator = clients
@@ -495,7 +495,7 @@ impl MlsGroupTestSetup {
             // Pick a random adder.
             let adder_id = group.random_group_member();
             // Add between 1 and 5 new members.
-            let number_of_adds = ((OsRng.next_u32() as usize) % 5 % new_members.len()) + 1;
+            let number_of_adds = ((rand::rng().next_u32() as usize) % 5 % new_members.len()) + 1;
             let members_to_add = new_members.drain(0..number_of_adds).collect();
             self.add_clients(ActionType::Commit, group, &adder_id.1, members_to_add)
                 .await?;
@@ -620,14 +620,14 @@ impl MlsGroupTestSetup {
         println!("Member performing the operation: {member_id:?}");
 
         // TODO: Do both things.
-        let action_type = match (OsRng.next_u32() as usize) % 2 {
+        let action_type = match (rand::rng().next_u32() as usize) % 2 {
             0 => ActionType::Proposal,
             1 => ActionType::Commit,
             _ => return Err(SetupError::Unknown),
         };
 
         // TODO: Do multiple things.
-        let operation_type = (OsRng.next_u32() as usize) % 3;
+        let operation_type = (rand::rng().next_u32() as usize) % 3;
         match operation_type {
             0 => {
                 println!("Performing a self-update with action type: {action_type:?}");
@@ -639,7 +639,7 @@ impl MlsGroupTestSetup {
                 if group.members.len() > 1 {
                     // How many members?
                     let number_of_removals =
-                        (((OsRng.next_u32() as usize) % group.members.len()) % 5) + 1;
+                        (((rand::rng().next_u32() as usize) % group.members.len()) % 5) + 1;
 
                     let (own_index, _) = group
                         .members
@@ -657,7 +657,7 @@ impl MlsGroupTestSetup {
                     for _ in 0..number_of_removals {
                         // Get a random index.
                         let mut member_list_index =
-                            (OsRng.next_u32() as usize) % group.members.len();
+                            (rand::rng().next_u32() as usize) % group.members.len();
                         // Re-sample until the index is not our own index and
                         // not one that is not already being removed.
                         let (mut leaf_index, mut identity) =
@@ -665,7 +665,8 @@ impl MlsGroupTestSetup {
                         while leaf_index == own_index
                             || target_member_identities.contains(&identity)
                         {
-                            member_list_index = (OsRng.next_u32() as usize) % group.members.len();
+                            member_list_index =
+                                (rand::rng().next_u32() as usize) % group.members.len();
                             let (new_leaf_index, new_identity) =
                                 group.members[member_list_index].clone();
                             leaf_index = new_leaf_index;
@@ -696,7 +697,8 @@ impl MlsGroupTestSetup {
                 // First, figure out if there are clients left to add.
                 let clients_left = self.clients.read().await.len() - group.members.len();
                 if clients_left > 0 {
-                    let number_of_adds = (((OsRng.next_u32() as usize) % clients_left) % 5) + 1;
+                    let number_of_adds =
+                        (((rand::rng().next_u32() as usize) % clients_left) % 5) + 1;
                     let new_member_ids = self
                         .random_new_members_for_group(group, number_of_adds)
                         .await

--- a/openmls/src/utils.rs
+++ b/openmls/src/utils.rs
@@ -1,22 +1,21 @@
 // === The folowing functions aren't necessarily cryptographically secure!
-
 #[cfg(any(feature = "test-utils", test))]
-use rand::{rngs::OsRng, RngCore};
+use rand::Rng as _;
 
 #[cfg(any(feature = "test-utils", test))]
 pub fn random_u32() -> u32 {
-    OsRng.next_u32()
+    rand::rng().next_u32()
 }
 
 #[cfg(any(feature = "test-utils", test))]
 pub fn random_u64() -> u64 {
-    OsRng.next_u64()
+    rand::rng().next_u64()
 }
 
 #[cfg(any(feature = "test-utils", test))]
 pub fn random_u8() -> u8 {
     let mut b = [0u8; 1];
-    OsRng.fill_bytes(&mut b);
+    rand::rng().fill_bytes(&mut b);
     b[0]
 }
 

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -14,20 +14,21 @@ async-trait = { workspace = true }
 openmls_traits = { version = "0.2.0", path = "../traits" }
 openmls_memory_keystore = { version = "0.2.0", path = "../memory_keystore" }
 # Rust Crypto dependencies
-sha2 = { version = "0.10" }
-aes-gcm = { version = "0.10" }
-chacha20poly1305 = { version = "0.10" }
-hmac = { version = "0.12" }
-ed25519-dalek = { version = "2.1", features = ["rand_core"] }
-p256 = { version = "0.13" }
-p384 = { version = "0.13" }
-p521 = { version = "0.13" }
-hkdf = { version = "0.12" }
-rand_core = "0.6"
-rand_chacha = { version = "0.3" }
+sha2 = { version = "0.11" }
+aes-gcm = { version = "0.11" }
+chacha20poly1305 = { version = "0.11" }
+hmac = { version = "0.13" }
+ed25519-dalek = { version = "3.0", features = ["rand_core"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
+p256 = { version = "0.14" }
+p384 = { version = "0.14" }
+p521 = { version = "0.14" }
+hkdf = { version = "0.13" }
+rand_core = "0.10"
+rand_chacha = "0.10"
 tls_codec = { workspace = true }
-zeroize = { version = "1.7", features = ["derive"] }
-signature = "2.1"
+zeroize = { version = "1.9", features = ["derive"] }
+signature = "3.0"
 thiserror = "1.0"
 generic-array = "0.14"
-hpke = { version = "0.12", features = ["x25519", "p256", "p384", "p521"] }
+hpke = { version = "0.14", features = ["x25519", "nistp", "aes"] }

--- a/openmls_rust_crypto/Cargo.toml
+++ b/openmls_rust_crypto/Cargo.toml
@@ -19,6 +19,7 @@ aes-gcm = { version = "0.11" }
 chacha20poly1305 = { version = "0.11" }
 hmac = { version = "0.13" }
 ed25519-dalek = { version = "3.0", features = ["rand_core"] }
+elliptic-curve = "0.14"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 p256 = { version = "0.14" }
 p384 = { version = "0.14" }

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -7,6 +7,7 @@ use aes_gcm::{
     Aes128Gcm, Aes256Gcm, KeyInit,
 };
 use chacha20poly1305::ChaCha20Poly1305;
+use elliptic_curve::Generate as _;
 use hkdf::Hkdf;
 use openmls_traits::{
     crypto::OpenMlsCrypto,
@@ -270,17 +271,17 @@ impl OpenMlsCrypto for RustCrypto {
 
         match alg {
             SignatureScheme::ECDSA_SECP256R1_SHA256 => {
-                let sk = p256::ecdsa::SigningKey::random(&mut *rng);
+                let sk = p256::ecdsa::SigningKey::generate_from_rng(&mut *rng);
                 let pk = sk.verifying_key().to_sec1_point(false).to_bytes().into();
                 Ok((sk.to_bytes().to_vec(), pk))
             }
             SignatureScheme::ECDSA_SECP384R1_SHA384 => {
-                let sk = p384::ecdsa::SigningKey::random(&mut *rng);
+                let sk = p384::ecdsa::SigningKey::generate_from_rng(&mut *rng);
                 let pk = sk.verifying_key().to_sec1_point(false).to_bytes().into();
                 Ok((sk.to_bytes().to_vec(), pk))
             }
             SignatureScheme::ECDSA_SECP521R1_SHA512 => {
-                let sk = p521::ecdsa::SigningKey::random(&mut *rng);
+                let sk = p521::ecdsa::SigningKey::generate_from_rng(&mut *rng);
                 let pk = p521::ecdsa::VerifyingKey::from(&sk)
                     .to_sec1_point(false)
                     .to_bytes()

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -1,5 +1,5 @@
-use rand_core::{RngCore, SeedableRng};
 use aes_gcm::aead;
+use rand_core::{SeedableRng, TryRng as _};
 use std::sync::RwLock;
 
 use aes_gcm::{
@@ -783,7 +783,7 @@ mod hpke_core {
         info: &[u8],
         aad: &[u8],
         plaintext: &[u8],
-        csprng: &mut impl rand_core::CryptoRngCore,
+        csprng: &mut impl rand_core::CryptoRng,
     ) -> Result<HpkeCiphertext, CryptoError> {
         use hpke::{Deserializable as _, Serializable as _};
         let key =
@@ -806,7 +806,7 @@ mod hpke_core {
 
     #[allow(dead_code)]
     pub fn hpke_gen_keypair<Kem: hpke::Kem>(
-        csprng: &mut impl rand_core::CryptoRngCore,
+        csprng: &mut impl rand_core::CryptoRng,
     ) -> Result<HpkeKeyPair, CryptoError> {
         use hpke::Serializable as _;
         let (sk, pk) = Kem::gen_keypair_with_rng(csprng);
@@ -852,7 +852,7 @@ mod hpke_core {
         info: &[u8],
         export_info: &[u8],
         export_len: usize,
-        csprng: &mut impl rand_core::CryptoRngCore,
+        csprng: &mut impl rand_core::CryptoRng,
     ) -> Result<(Vec<u8>, Vec<u8>), CryptoError> {
         use hpke::{Deserializable as _, Serializable as _};
         let key =

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -1,4 +1,5 @@
 use rand_core::{RngCore, SeedableRng};
+use aes_gcm::aead;
 use std::sync::RwLock;
 
 use aes_gcm::{
@@ -185,12 +186,17 @@ impl OpenMlsCrypto for RustCrypto {
         nonce: &[u8],
         aad: &[u8],
     ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        // All supported algorithms use the same nonce size of 96 bits, so
+        // picking any of them for the generic parameter of Nonce<A> is fine.
+        let nonce =
+            aead::Nonce::<Aes128Gcm>::try_from(nonce).map_err(|_| CryptoError::InvalidLength)?;
+
         match alg {
             AeadType::Aes128Gcm => {
                 let aes =
                     Aes128Gcm::new_from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
 
-                aes.encrypt(nonce.into(), Payload { msg: data, aad })
+                aes.encrypt(&nonce, Payload { msg: data, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadEncryptionError)
             }
@@ -198,7 +204,7 @@ impl OpenMlsCrypto for RustCrypto {
                 let aes =
                     Aes256Gcm::new_from_slice(key).map_err(|_| CryptoError::AeadEncryptionError)?;
 
-                aes.encrypt(nonce.into(), Payload { msg: data, aad })
+                aes.encrypt(&nonce, Payload { msg: data, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadEncryptionError)
             }
@@ -207,7 +213,7 @@ impl OpenMlsCrypto for RustCrypto {
                     .map_err(|_| CryptoError::AeadEncryptionError)?;
 
                 chacha_poly
-                    .encrypt(nonce.into(), Payload { msg: data, aad })
+                    .encrypt(&nonce, Payload { msg: data, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadEncryptionError)
             }
@@ -222,18 +228,23 @@ impl OpenMlsCrypto for RustCrypto {
         nonce: &[u8],
         aad: &[u8],
     ) -> Result<Vec<u8>, openmls_traits::types::CryptoError> {
+        // All supported algorithms use the same nonce size of 96 bits, so
+        // picking any of them for the generic parameter of Nonce<A> is fine.
+        let nonce =
+            aead::Nonce::<Aes128Gcm>::try_from(nonce).map_err(|_| CryptoError::InvalidLength)?;
+
         match alg {
             AeadType::Aes128Gcm => {
                 let aes =
                     Aes128Gcm::new_from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
-                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                aes.decrypt(&nonce, Payload { msg: ct_tag, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadDecryptionError)
             }
             AeadType::Aes256Gcm => {
                 let aes =
                     Aes256Gcm::new_from_slice(key).map_err(|_| CryptoError::CryptoLibraryError)?;
-                aes.decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                aes.decrypt(&nonce, Payload { msg: ct_tag, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadDecryptionError)
             }
@@ -241,7 +252,7 @@ impl OpenMlsCrypto for RustCrypto {
                 let chacha_poly = ChaCha20Poly1305::new_from_slice(key)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
                 chacha_poly
-                    .decrypt(nonce.into(), Payload { msg: ct_tag, aad })
+                    .decrypt(&nonce, Payload { msg: ct_tag, aad })
                     .map(|r| r.as_slice().into())
                     .map_err(|_| CryptoError::AeadDecryptionError)
             }

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -777,7 +777,7 @@ mod hpke_core {
         use hpke::{Deserializable as _, Serializable as _};
         let key =
             Kem::PublicKey::from_bytes(public_key).map_err(|_| CryptoError::HpkeEncryptionError)?;
-        let (encapped, ciphertext) = hpke::single_shot_seal::<Aead, Kdf, Kem, _>(
+        let (encapped, ciphertext) = hpke::single_shot_seal_with_rng::<Aead, Kdf, Kem>(
             &hpke::OpModeS::Base,
             &key,
             info,
@@ -798,7 +798,7 @@ mod hpke_core {
         csprng: &mut impl rand_core::CryptoRngCore,
     ) -> Result<HpkeKeyPair, CryptoError> {
         use hpke::Serializable as _;
-        let (sk, pk) = Kem::gen_keypair(csprng);
+        let (sk, pk) = Kem::gen_keypair_with_rng(csprng);
         let (private, public) = (sk.to_bytes().to_vec().into(), pk.to_bytes().to_vec());
 
         Ok(HpkeKeyPair { private, public })
@@ -847,7 +847,7 @@ mod hpke_core {
         let key =
             Kem::PublicKey::from_bytes(tx_public_key).map_err(|_| CryptoError::SenderSetupError)?;
         let (kem_output, ctx) =
-            hpke::setup_sender::<Aead, Kdf, Kem, _>(&hpke::OpModeS::Base, &key, info, csprng)
+            hpke::setup_sender_with_rng::<Aead, Kdf, Kem>(&hpke::OpModeS::Base, &key, info, csprng)
                 .map_err(|_| CryptoError::SenderSetupError)?;
 
         let mut export = vec![0u8; export_len];

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -260,18 +260,18 @@ impl OpenMlsCrypto for RustCrypto {
         match alg {
             SignatureScheme::ECDSA_SECP256R1_SHA256 => {
                 let sk = p256::ecdsa::SigningKey::random(&mut *rng);
-                let pk = sk.verifying_key().to_encoded_point(false).to_bytes().into();
+                let pk = sk.verifying_key().to_sec1_point(false).to_bytes().into();
                 Ok((sk.to_bytes().to_vec(), pk))
             }
             SignatureScheme::ECDSA_SECP384R1_SHA384 => {
                 let sk = p384::ecdsa::SigningKey::random(&mut *rng);
-                let pk = sk.verifying_key().to_encoded_point(false).to_bytes().into();
+                let pk = sk.verifying_key().to_sec1_point(false).to_bytes().into();
                 Ok((sk.to_bytes().to_vec(), pk))
             }
             SignatureScheme::ECDSA_SECP521R1_SHA512 => {
                 let sk = p521::ecdsa::SigningKey::random(&mut *rng);
                 let pk = p521::ecdsa::VerifyingKey::from(&sk)
-                    .to_encoded_point(false)
+                    .to_sec1_point(false)
                     .to_bytes()
                     .into();
                 Ok((sk.to_bytes().to_vec(), pk))

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -383,7 +383,7 @@ impl OpenMlsCrypto for RustCrypto {
 
         match alg {
             SignatureScheme::ECDSA_SECP256R1_SHA256 => {
-                let k = p256::ecdsa::SigningKey::from_bytes(key.into())
+                let k = p256::ecdsa::SigningKey::from_slice(key)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
                 let signature: p256::ecdsa::DerSignature = k
                     .try_sign(data)
@@ -391,7 +391,7 @@ impl OpenMlsCrypto for RustCrypto {
                 Ok(signature.to_bytes().into())
             }
             SignatureScheme::ECDSA_SECP384R1_SHA384 => {
-                let k = p384::ecdsa::SigningKey::from_bytes(key.into())
+                let k = p384::ecdsa::SigningKey::from_slice(key)
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
                 let signature: p384::ecdsa::DerSignature = k
                     .try_sign(data)
@@ -401,8 +401,8 @@ impl OpenMlsCrypto for RustCrypto {
             SignatureScheme::ECDSA_SECP521R1_SHA512 => {
                 let k = p521::ecdsa::SigningKey::from_slice(&*normalize_p521_secret_key(key))
                     .map_err(|_| CryptoError::CryptoLibraryError)?;
-                let signature: p521::ecdsa::DerSignature = k
-                    .try_sign(data)
+                let signature: p521::ecdsa::DerSignature = <p521::ecdsa::SigningKey as signature::Signer<p521::ecdsa::Signature>>::
+                    try_sign(&k, data)
                     .map_err(|_| CryptoError::CryptoLibraryError)?
                     .to_der();
                 Ok(signature.to_bytes().into())

--- a/openmls_rust_crypto/src/provider.rs
+++ b/openmls_rust_crypto/src/provider.rs
@@ -68,9 +68,9 @@ pub struct RustCrypto {
 
 impl Default for RustCrypto {
     fn default() -> Self {
-        Self {
-            rng: RwLock::new(rand_chacha::ChaCha20Rng::from_entropy()),
-        }
+        let mut seed = RawEntropySeed::default();
+        getrandom::fill(&mut seed).expect("system RNG has to work");
+        Self::new_with_seed(EntropySeed::from_raw(seed))
     }
 }
 

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -18,13 +18,13 @@ test-utils = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rand_core = "0.6"
+rand_core = "0.10"
 tls_codec = { workspace = true }
 async-trait = { workspace = true }
 # for the default signer
-ed25519-dalek = { version = "2.1", features = ["rand_core"] }
-p256 = "0.13"
-p384 = "0.13"
-p521 = "0.13"
-zeroize = "1.6"
-signature = "2.1"
+ed25519-dalek = { version = "3.0", features = ["rand_core"] }
+p256 = "0.14"
+p384 = "0.14"
+p521 = "0.14"
+zeroize = "1.9"
+signature = "3.0"

--- a/traits/src/random.rs
+++ b/traits/src/random.rs
@@ -5,7 +5,7 @@
 
 pub trait OpenMlsRand {
     type Error: std::error::Error + std::fmt::Debug;
-    type RandImpl: rand_core::CryptoRngCore;
+    type RandImpl: rand_core::CryptoRng;
     type BorrowTarget<'a>: std::ops::DerefMut<Target = Self::RandImpl>
     where
         Self: 'a;


### PR DESCRIPTION
This updates various RustCrypto dependencies and fixes test failures, which fall into two categories:
- futures blowing up the stack
- broken tests attempting UB 

The first is fixed simply by moving the test futures to heap, while the second is fixed by removing the relevant test code (changes cherry-picked from upstream).

While diffstat may seem huge, in reality it is not as most changes are just whitespace changes (e.g. `git diff/show -w` should help).